### PR TITLE
Export Result, Ok, Err

### DIFF
--- a/.changeset/quiet-berries-occur.md
+++ b/.changeset/quiet-berries-occur.md
@@ -1,0 +1,5 @@
+---
+"safe-fn": patch
+---
+
+Renames `Ok()` and `Err()` to `ok()` and `err()` to avoid overlap with types. Exports `ok()`, `err()`, `Ok`, `Err`, `Result` to be available to users.

--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ export const createUser = SafeFn.new()
   .action(async (input) => {
     try {
       const user = await db.user.insert(input.parsedInput);
-      return Ok(user);
+      return ok(user);
     } catch (error) {
       if (error instanceof DbError) {
         if (error.code === "UNIQUE_CONSTRAINT") {
-          return Err({
+          return err({
             code: "DUPLICATE_USER",
             message: "User already exists",
           });
         }
       }
 
-      return Err({
+      return err({
         code: "INTERNAL_ERROR",
         message: "Something went wrong",
       });
@@ -86,7 +86,7 @@ const safeFn = SafeFn.new()
     }),
   )
   .error((error) => {
-    return Err({
+    return err({
       code: "CAUGHT_ERROR",
       cause,
     });
@@ -94,14 +94,14 @@ const safeFn = SafeFn.new()
   .action(async ({ parsedInput }) => {
     const isProfane = await isProfaneName(parsedInput.firstName);
     if (isProfane) {
-      return Err({
+      return err({
         code: "PROFANE_NAME",
         message: "Name is profane",
       });
     }
 
     const fullName = `${parsedInput.firstName} ${parsedInput.lastName}`;
-    return Ok({ fullName });
+    return ok({ fullName });
   });
 ```
 

--- a/packages/safe-fn/src/index.ts
+++ b/packages/safe-fn/src/index.ts
@@ -1,3 +1,4 @@
+import { type Err, type Ok, type Result, err, ok } from "./result";
 import { SafeFn } from "./safe-fn";
 
 import type {
@@ -23,14 +24,19 @@ export type {
   AnySafeFn,
   AnySafeFnThrownHandler,
   BuilderSteps,
+  Err,
   InferInputSchema,
   InferOutputSchema,
   InferRunArgs,
   InferUnparsedInput,
+  Ok,
+  Result,
   SafeFnActionFn,
   SafeFnReturn,
   SafeFnReturnData,
   SafeFnReturnError,
   SafeFnRunArgs,
   TSafeFn,
+  err,
+  ok,
 };

--- a/packages/safe-fn/src/result.ts
+++ b/packages/safe-fn/src/result.ts
@@ -8,7 +8,7 @@ export type Ok<TData> = {
 };
 export type InferOkData<T> = T extends Ok<infer TData> ? TData : never;
 
-export const Ok = <const TData>(data: TData): Ok<TData> => ({
+export const ok = <const TData>(data: TData): Ok<TData> => ({
   success: true,
   data,
   error: undefined as never,
@@ -22,7 +22,7 @@ export type Err<TError> = {
 export type InferErrError<T> = T extends Err<infer TError> ? TError : never;
 
 export type AnyErr = Err<any>;
-export const Err = <const TError>(error: TError): Err<TError> => ({
+export const err = <const TError>(error: TError): Err<TError> => ({
   success: false,
   error,
   data: undefined as never,

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
-import { Err, Ok, type InferErrError, type Result } from "./result";
+import { err, ok, type Err, type InferErrError, type Result } from "./result";
 import { SafeFn } from "./safe-fn";
 import type {
   SafeFnDefaultThrowHandler,
@@ -265,7 +265,7 @@ describe("run", () => {
       const inputSchema = z.string();
       const safeFn = SafeFn.new()
         .input(inputSchema)
-        .action((args) => Ok(args.parsedInput));
+        .action((args) => ok(args.parsedInput));
 
       type RunInput = Parameters<typeof safeFn.run>[0];
 
@@ -281,7 +281,7 @@ describe("run", () => {
       });
       const safeFn = SafeFn.new()
         .input(inputSchema)
-        .action((args) => Ok(args.parsedInput));
+        .action((args) => ok(args.parsedInput));
 
       type RunInput = Parameters<typeof safeFn.run>[0];
 
@@ -299,7 +299,7 @@ describe("run", () => {
         .transform(({ test }) => ({ test, newProperty: "test" }));
       const safeFn = SafeFn.new()
         .input(inputSchema)
-        .action((args) => Ok(args.parsedInput));
+        .action((args) => ok(args.parsedInput));
 
       type RunInput = Parameters<typeof safeFn.run>[0];
 
@@ -320,7 +320,7 @@ describe("run", () => {
     //   >();
     // });
     test("should infer success return type from action when no output schema is provided", async () => {
-      const safeFn = SafeFn.new().action(() => Ok("data" as const));
+      const safeFn = SafeFn.new().action(() => ok("data" as const));
 
       expectTypeOf(safeFn.run({})).resolves.toMatchTypeOf<
         Result<"data", any>
@@ -331,7 +331,7 @@ describe("run", () => {
       const outputSchema = z.string().transform((data) => data + "!");
       const safeFn = SafeFn.new()
         .output(outputSchema)
-        .action(() => Ok(""));
+        .action(() => ok(""));
 
       const res = await safeFn.run({});
       expectTypeOf(res).toMatchTypeOf<
@@ -342,7 +342,7 @@ describe("run", () => {
 
   describe("error", () => {
     test("should infer Err return as default when no error function is set", async () => {
-      const safeFn = SafeFn.new().action(() => Ok("data" as const));
+      const safeFn = SafeFn.new().action(() => ok("data" as const));
 
       type Res = Awaited<ReturnType<typeof safeFn.run>>;
       type InferredErrError = InferErrError<Res>;
@@ -352,7 +352,7 @@ describe("run", () => {
     });
 
     test("should infer Err return type from action when no error function is set", async () => {
-      const safeFn = SafeFn.new().action(() => Err("my error" as const));
+      const safeFn = SafeFn.new().action(() => err("my error" as const));
       type Res = Awaited<ReturnType<typeof safeFn.run>>;
       type InferredErrError = InferErrError<Res>;
       expectTypeOf<InferredErrError>().toEqualTypeOf<
@@ -363,9 +363,9 @@ describe("run", () => {
     test("should infer Err return type from action when error function is set", async () => {
       const safeFn = SafeFn.new()
         .action(() => {
-          return Err("error" as const);
+          return err("error" as const);
         })
-        .error(() => Err("thrown" as const));
+        .error(() => err("thrown" as const));
 
       type Res = Awaited<ReturnType<typeof safeFn.run>>;
       type InferredErrError = InferErrError<Res>;
@@ -471,7 +471,7 @@ describe("internals", () => {
 
 describe("error", () => {
   test("should properly type the _uncaughtErrorHandler function", () => {
-    const safeFn = SafeFn.new().error((error) => Err("hello" as const));
+    const safeFn = SafeFn.new().error((error) => err("hello" as const));
 
     type res = ReturnType<typeof safeFn._uncaughtErrorHandler>;
     expectTypeOf(safeFn._uncaughtErrorHandler).toEqualTypeOf<
@@ -484,7 +484,7 @@ describe("parent", () => {
   test("should properly type the _parent function", () => {
     const safeFn1 = SafeFn.new()
       .input(z.object({ name: z.string() }))
-      .action(() => Ok(""));
+      .action(() => ok(""));
     const safeFn2 = SafeFn.new(safeFn1).input(z.object({ age: z.number() }));
     expectTypeOf(safeFn2._parent).toEqualTypeOf(safeFn1);
   });
@@ -499,7 +499,7 @@ describe("parent", () => {
           const input2 = z.object({ age: z.number() });
           const safeFn1 = SafeFn.new()
             .input(input1)
-            .action(() => Ok(""));
+            .action(() => ok(""));
           const safeFn2 = SafeFn.new(safeFn1).input(input2);
 
           type S2ParsedInput = Parameters<
@@ -525,7 +525,7 @@ describe("parent", () => {
 
           const safeFn1 = SafeFn.new()
             .input(input1)
-            .action(() => Ok(""));
+            .action(() => ok(""));
           const safeFn2 = SafeFn.new(safeFn1).input(input2);
 
           type S2ParsedInput = Parameters<
@@ -539,7 +539,7 @@ describe("parent", () => {
 
         test("should take parsedInput from child when parent has no input schema", () => {
           const input = z.object({ name: z.string() });
-          const safeFn1 = SafeFn.new().action((args) => Ok(args.parsedInput));
+          const safeFn1 = SafeFn.new().action((args) => ok(args.parsedInput));
           const safeFn2 = SafeFn.new(safeFn1).input(input);
 
           type S2ParsedInput = Parameters<
@@ -553,7 +553,7 @@ describe("parent", () => {
           const input = z.object({ name: z.string() });
           const safeFn1 = SafeFn.new()
             .input(input)
-            .action(() => Ok(""));
+            .action(() => ok(""));
           const safeFn2 = SafeFn.new(safeFn1);
 
           type S2ParsedInput = Parameters<
@@ -566,7 +566,7 @@ describe("parent", () => {
 
       describe("ctx", () => {
         test("should type ctx as unwrapped OK value from parent", () => {
-          const safeFn1 = SafeFn.new().action(() => Ok("ctx return" as const));
+          const safeFn1 = SafeFn.new().action(() => ok("ctx return" as const));
           const safeFn2 = SafeFn.new(safeFn1);
 
           type S2Ctx = Parameters<
@@ -576,7 +576,7 @@ describe("parent", () => {
         });
 
         test("should type ctx as empty object if parent never returns", () => {
-          const safeFn1 = SafeFn.new().action(() => Err("ctx return" as const));
+          const safeFn1 = SafeFn.new().action(() => err("ctx return" as const));
           const safeFn2 = SafeFn.new(safeFn1);
 
           type S2Ctx = Parameters<

--- a/packages/safe-fn/src/safe-fn.ts
+++ b/packages/safe-fn/src/safe-fn.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { Err, Ok, type Result } from "./result";
+import { err, ok, type Err, type Result } from "./result";
 import type {
   AnyRunnableSafeFn,
   AnySafeFnThrownHandler,
@@ -73,11 +73,11 @@ export class SafeFn<
       inputSchema: undefined,
       outputSchema: undefined,
       actionFn: () =>
-        Err({
+        err({
           code: "NO_ACTION",
         } as const),
       uncaughtErrorHandler: (error: unknown) =>
-        Err({
+        err({
           code: "UNCAUGHT_ERROR",
           cause: error,
         } as const),
@@ -280,10 +280,10 @@ export class SafeFn<
     const res = await this._inputSchema.safeParseAsync(input);
 
     if (res.success) {
-      return Ok(res.data);
+      return ok(res.data);
     }
 
-    return Err({
+    return err({
       code: "INPUT_PARSING",
       cause: res.error,
     }) as Err<SafeFnInputParseError<TInputSchema>>;
@@ -304,10 +304,10 @@ export class SafeFn<
     const res = await this._outputSchema.safeParseAsync(output);
 
     if (res.success) {
-      return Ok(res.data);
+      return ok(res.data);
     }
 
-    return Err({
+    return err({
       code: "OUTPUT_PARSING",
       cause: res.error,
     }) as Err<SafeFnOutputParseError<TOutputSchema>>;

--- a/packages/safe-fn/src/types.ts
+++ b/packages/safe-fn/src/types.ts
@@ -248,8 +248,8 @@ export type SafeFnReturnData<
  * @param TActionFn the action function of the safe function
  * @param TThrownHandler the thrown handler of the safe function
  * @returns the error type of the return value of the safe function after unsuccessful execution. This is a union of all possible error types that can be thrown by the safe function consisting off:
- * - A union of all `Err()` returns of the action function
- * - A union of all `Err()` returns of the uncaught error handler
+ * - A union of all `Err` returns of the action function
+ * - A union of all `Err` returns of the uncaught error handler
  * - A `SafeFnInputParseError` if the input schema is defined and the input could not be parsed
  * - A `SafeFnOutputParseError` if the output schema is defined and the output could not be parsed
  * Note that this is wrapped in a `Result` type.
@@ -304,7 +304,7 @@ export type SafeFnRunArgs<
  * @param TOutputSchema a Zod schema or undefined
  * @param TActionFn the action function of the safe function
  * @param TThrownHandler the thrown handler of the safe function
- * @returns the return value of the safe function after execution. This is a `Result` type that can either be an `Ok()` or an `Err()`.
+ * @returns the return value of the safe function after execution. This is a `Result` type that can either be an `Ok` or an `Err`.
  * 
  * @example
  * ```ts
@@ -321,7 +321,7 @@ export type SafeFnRunArgs<
     }),
   )
   .error((error) => {
-    return Err({
+    return err({
       code: "CAUGHT_ERROR",
       error,
     });
@@ -329,14 +329,14 @@ export type SafeFnRunArgs<
   .action(async ({ parsedInput }) => {
     const isProfane = await isProfaneName(parsedInput.firstName);
     if (isProfane) {
-      return Err({
+      return err({
         code: "PROFANE_NAME",
         message: "Name is profane",
       });
     }
 
     const fullName = `${parsedInput.firstName} ${parsedInput.lastName}`;
-    return Ok({ fullName });
+    return ok({ fullName });
   });
  * ```
 

--- a/packages/safe-fn/src/types.ts
+++ b/packages/safe-fn/src/types.ts
@@ -1,4 +1,4 @@
-import type { ZodTypeAny, z } from "zod";
+import type { z, ZodTypeAny } from "zod";
 import type {
   AnyResult,
   Err,


### PR DESCRIPTION
Renames `Ok()` and `Err()` to `ok()` and `err()` to avoid overlap with types. Exports `ok()`, `err()`, `Ok`, `Err`, `Result` to be available to users.