### PR TITLE
Temporary workaround for default error handler passing errror to the client

### DIFF
--- a/.changeset/breezy-glasses-taste.md
+++ b/.changeset/breezy-glasses-taste.md
@@ -1,0 +1,5 @@
+---
+"safe-fn": patch
+---
+
+Temporary fix for [#15](https://github.com/janglad/safe-fn/issues/15). By default errors are now not passed along but logged.

--- a/packages/safe-fn/src/safe-fn-builder.ts
+++ b/packages/safe-fn/src/safe-fn-builder.ts
@@ -5,6 +5,8 @@ import { RunnableSafeFn } from "./runnable-safe-fn";
 import type {
   AnyRunnableSafeFn,
   Prettify,
+  SafeFnDefaultHandlerFn,
+  SafeFnDefaultThrowHandler,
   SafeFnDefaultThrownHandlerErr,
   SafeFnHandlerArgs,
   SafeFnHandlerReturn,
@@ -51,15 +53,19 @@ export class SafeFnBuilder<
       parent,
       inputSchema: undefined,
       outputSchema: undefined,
-      handler: () =>
+      handler: (() =>
         err({
           code: "NO_HANDLER",
-        } as const),
-      uncaughtErrorHandler: (error: unknown) =>
-        err({
+        } as const)) satisfies SafeFnDefaultHandlerFn,
+      uncaughtErrorHandler: ((error: unknown) => {
+        // TODO: Keep track of asAction both at compile and run time, switch error input based on that.
+        console.error(error);
+        return err({
           code: "UNCAUGHT_ERROR",
-          cause: error,
-        } as const),
+          cause:
+            "An uncaught error occurred. You can implement a custom error handler by using `error()`",
+        } as const);
+      }) satisfies SafeFnDefaultThrowHandler,
     }) as any;
   }
 

--- a/packages/safe-fn/src/types.ts
+++ b/packages/safe-fn/src/types.ts
@@ -156,7 +156,7 @@ export type SafeFnDefaultThrownHandlerErr = Err<
   never,
   {
     code: "UNCAUGHT_ERROR";
-    cause: unknown;
+    cause: "An uncaught error occurred. You can implement a custom error handler by using `error()`";
   }
 >;
 


### PR DESCRIPTION
Kinda fixes #15, also see #23 