### PR TITLE
rename error to catch to prevent confusion

### DIFF
--- a/packages/safe-fn/src/index.ts
+++ b/packages/safe-fn/src/index.ts
@@ -15,7 +15,7 @@ import { SafeFnBuilder } from "./safe-fn-builder";
 import type {
   AnyRunnableSafeFn,
   AnySafeFnAction,
-  AnySafeFnThrownHandler,
+  AnySafeFnCatchHandler,
   InferInputSchema,
   InferOutputSchema,
   InferSafeFnActionArgs,
@@ -46,7 +46,7 @@ export type {
   ActionResultToResult,
   AnyRunnableSafeFn,
   AnySafeFnAction,
-  AnySafeFnThrownHandler,
+  AnySafeFnCatchHandler,
   Err,
   InferActionErrError,
   InferActionOkData,

--- a/packages/safe-fn/src/runnable-safe-fn.ts
+++ b/packages/safe-fn/src/runnable-safe-fn.ts
@@ -3,8 +3,8 @@ import { ResultAsync, safeTry } from "neverthrow";
 import { actionErr, actionOk, ok } from "./result";
 import type {
   AnyRunnableSafeFn,
+  AnySafeFnCatchHandlerRes,
   AnySafeFnHandlerRes,
-  AnySafeFnThrownHandlerRes,
   SafeFnAction,
   SafeFnActionArgs,
   SafeFnActionReturn,
@@ -24,7 +24,7 @@ export class RunnableSafeFn<
   TOutputSchema extends SafeFnInput,
   TUnparsedInput,
   THandlerRes extends AnySafeFnHandlerRes,
-  TThrownHandlerRes extends AnySafeFnThrownHandlerRes,
+  TThrownHandlerRes extends AnySafeFnCatchHandlerRes,
 > {
   readonly _internals: SafeFnInternals<
     TParent,
@@ -64,7 +64,7 @@ export class RunnableSafeFn<
 ################################
 */
 
-  error<TNewThrownHandlerRes extends AnySafeFnThrownHandlerRes>(
+  catch<TNewThrownHandlerRes extends AnySafeFnCatchHandlerRes>(
     handler: (error: unknown) => TNewThrownHandlerRes,
   ): RunnableSafeFn<
     TParent,

--- a/packages/safe-fn/src/safe-fn-builder.ts
+++ b/packages/safe-fn/src/safe-fn-builder.ts
@@ -5,9 +5,9 @@ import { RunnableSafeFn } from "./runnable-safe-fn";
 import type {
   AnyRunnableSafeFn,
   Prettify,
+  SafeFnDefaultCatchHandler,
+  SafeFnDefaultCatchHandlerErr,
   SafeFnDefaultHandlerFn,
-  SafeFnDefaultThrowHandler,
-  SafeFnDefaultThrownHandlerErr,
   SafeFnHandlerArgs,
   SafeFnHandlerReturn,
   SafeFnInput,
@@ -63,9 +63,9 @@ export class SafeFnBuilder<
         return err({
           code: "UNCAUGHT_ERROR",
           cause:
-            "An uncaught error occurred. You can implement a custom error handler by using `error()`",
+            "An uncaught error occurred. You can implement a custom error handler by using `catch()`",
         } as const);
-      }) satisfies SafeFnDefaultThrowHandler,
+      }) satisfies SafeFnDefaultCatchHandler,
     }) as any;
   }
 
@@ -121,7 +121,7 @@ export class SafeFnBuilder<
     TOutputSchema,
     TUnparsedInput,
     TNewHandlerResult,
-    SafeFnDefaultThrownHandlerErr
+    SafeFnDefaultCatchHandlerErr
   > {
     return new RunnableSafeFn({
       ...this._internals,
@@ -148,7 +148,7 @@ export class SafeFnBuilder<
     [YieldErr] extends [never]
       ? GeneratorResult
       : MergeResults<GeneratorResult, YieldErr>,
-    SafeFnDefaultThrownHandlerErr
+    SafeFnDefaultCatchHandlerErr
   > {
     const handler = async (
       args: Prettify<SafeFnHandlerArgs<TInputSchema, TUnparsedInput, TParent>>,

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -5,7 +5,7 @@ import { err, ok, type Result } from "./result";
 import { SafeFnBuilder } from "./safe-fn-builder";
 import type {
   Prettify,
-  SafeFnDefaultThrownHandlerErr,
+  SafeFnDefaultCatchHandlerErr,
   SafeFnInputParseError,
   SafeFnOutputParseError,
 } from "./types";
@@ -653,7 +653,7 @@ describe("runnableSafeFn", () => {
         expectTypeOf(resultSafe.value).toEqualTypeOf<"hello">();
       });
 
-      test("should type Err as default when no error handler is provided", async () => {
+      test("should type Err as default when no catch handler is provided", async () => {
         const safeFn = SafeFnBuilder.new();
         const safeFnSync = safeFn.handler(() => ok("hello" as const));
         const safeFnAsync = safeFn.handler(async () => ok("hello" as const));
@@ -670,29 +670,29 @@ describe("runnableSafeFn", () => {
         assert(resultSafe.isErr());
 
         expectTypeOf(resultSync.error).toEqualTypeOf<
-          SafeFnDefaultThrownHandlerErr["error"]
+          SafeFnDefaultCatchHandlerErr["error"]
         >();
         expectTypeOf(resultAsync.error).toEqualTypeOf<
-          SafeFnDefaultThrownHandlerErr["error"]
+          SafeFnDefaultCatchHandlerErr["error"]
         >();
         expectTypeOf(resultSafe.error).toEqualTypeOf<
-          SafeFnDefaultThrownHandlerErr["error"]
+          SafeFnDefaultCatchHandlerErr["error"]
         >();
       });
 
-      test("should type Err as custom when error handler is provided", async () => {
+      test("should type Err as custom when catch handler is provided", async () => {
         const safeFn = SafeFnBuilder.new();
         const safeFnSync = safeFn
           .handler(() => ok("hello" as const))
-          .error(() => err("world" as const));
+          .catch(() => err("world" as const));
         const safeFnAsync = safeFn
           .handler(async () => ok("hello" as const))
-          .error(() => err("world" as const));
+          .catch(() => err("world" as const));
         const safeFnSafe = safeFn
           .safeHandler(async function* () {
             return ok("hello" as const);
           })
-          .error(() => err("world" as const));
+          .catch(() => err("world" as const));
 
         const resultSync = await safeFnSync.run();
         const resultAsync = await safeFnAsync.run();
@@ -724,13 +724,13 @@ describe("runnableSafeFn", () => {
         assert(resultSafe.isErr());
 
         expectTypeOf(resultSync.error).toEqualTypeOf<
-          "hello" | SafeFnDefaultThrownHandlerErr["error"]
+          "hello" | SafeFnDefaultCatchHandlerErr["error"]
         >();
         expectTypeOf(resultAsync.error).toEqualTypeOf<
-          "hello" | SafeFnDefaultThrownHandlerErr["error"]
+          "hello" | SafeFnDefaultCatchHandlerErr["error"]
         >();
         expectTypeOf(resultSafe.error).toEqualTypeOf<
-          "hello" | SafeFnDefaultThrownHandlerErr["error"]
+          "hello" | SafeFnDefaultCatchHandlerErr["error"]
         >();
       });
 
@@ -738,15 +738,15 @@ describe("runnableSafeFn", () => {
         const safeFn = SafeFnBuilder.new();
         const safeFnSync = safeFn
           .handler(() => err("hello" as const))
-          .error(() => err("world" as const));
+          .catch(() => err("world" as const));
         const safeFnAsync = safeFn
           .handler(async () => err("hello" as const))
-          .error(() => err("world" as const));
+          .catch(() => err("world" as const));
         const safeFnSafe = safeFn
           .safeHandler(async function* () {
             return err("hello" as const);
           })
-          .error(() => err("world" as const));
+          .catch(() => err("world" as const));
 
         const resultSync = await safeFnSync.run();
         const resultAsync = await safeFnAsync.run();
@@ -774,13 +774,13 @@ describe("runnableSafeFn", () => {
         const resultSafe = await safeFnSafe.run();
 
         expectTypeOf(resultSync).toEqualTypeOf<
-          Result<never, "hello" | SafeFnDefaultThrownHandlerErr["error"]>
+          Result<never, "hello" | SafeFnDefaultCatchHandlerErr["error"]>
         >();
         expectTypeOf(resultAsync).toEqualTypeOf<
-          Result<never, "hello" | SafeFnDefaultThrownHandlerErr["error"]>
+          Result<never, "hello" | SafeFnDefaultCatchHandlerErr["error"]>
         >();
         expectTypeOf(resultSafe).toEqualTypeOf<
-          Result<never, "hello" | SafeFnDefaultThrownHandlerErr["error"]>
+          Result<never, "hello" | SafeFnDefaultCatchHandlerErr["error"]>
         >();
       });
 
@@ -824,7 +824,7 @@ describe("runnableSafeFn", () => {
 
         type ExpectedResult = Result<
           "hello",
-          "world" | SafeFnDefaultThrownHandlerErr["error"]
+          "world" | SafeFnDefaultCatchHandlerErr["error"]
         >;
 
         expectTypeOf(resultSync).toEqualTypeOf<ExpectedResult>();
@@ -922,24 +922,24 @@ describe("runnableSafeFn", () => {
 
         const safeActionSync = safeFn
           .handler(() => ok("hello"))
-          .error(() => err("world" as const))
+          .catch(() => err("world" as const))
           .createAction();
         const safeActionAsync = safeFn
           .handler(async () => ok("hello"))
-          .error(() => err("world" as const))
+          .catch(() => err("world" as const))
           .createAction();
         const safeActionSafe = safeFn
           .safeHandler(async function* () {
             return ok("hello" as const);
           })
-          .error(() => err("world" as const))
+          .catch(() => err("world" as const))
           .createAction();
         const safeActionSafeYield = safeFn
           .safeHandler(async function* () {
             yield* err("world2" as const).safeUnwrap();
             return ok("hello");
           })
-          .error(() => err("world" as const))
+          .catch(() => err("world" as const))
           .createAction();
 
         type ExpectedInputParseError = SafeFnInputParseError<

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -61,7 +61,7 @@ describe("safe-fn-builder", () => {
       });
     });
 
-    test("should set the correct default error handler", () => {
+    test("should set the correct default catch handler", () => {
       const builder = SafeFnBuilder.new();
       const returnedError = builder._internals.uncaughtErrorHandler(
         undefined as TODO,
@@ -152,12 +152,12 @@ describe("safe-fn-builder", () => {
 });
 
 describe("runnable-safe-fn", () => {
-  describe("error", () => {
-    test("should set the error handler", () => {
+  describe("catch", () => {
+    test("should set the catch handler", () => {
       const errorHandler = () => err("error");
       const safeFn = SafeFnBuilder.new()
         .handler(() => ok(""))
-        .error(errorHandler);
+        .catch(errorHandler);
       expect(safeFn._internals.uncaughtErrorHandler).toEqual(errorHandler);
     });
   });
@@ -395,7 +395,7 @@ describe("runnable-safe-fn", () => {
               .handler(() => {
                 throw new Error("error");
               })
-              .error((e) =>
+              .catch((e) =>
                 err({
                   code: "TEST_ERROR",
                   cause: e,
@@ -409,7 +409,7 @@ describe("runnable-safe-fn", () => {
               .handler(async () => {
                 throw new Error("error");
               })
-              .error((e) =>
+              .catch((e) =>
                 err({
                   code: "TEST_ERROR",
                   cause: e,
@@ -423,7 +423,7 @@ describe("runnable-safe-fn", () => {
               .safeHandler(async function* () {
                 throw new Error("error");
               })
-              .error((e) =>
+              .catch((e) =>
                 err({
                   code: "TEST_ERROR",
                   cause: e,
@@ -433,7 +433,7 @@ describe("runnable-safe-fn", () => {
       ];
 
       testCases.forEach(({ name, createSafeFn }) => {
-        test(`should run error handler for ${name} handler`, async () => {
+        test(`should run catch handler for ${name} handler`, async () => {
           const safeFn = createSafeFn();
           const res = await safeFn.run();
           expect(res).toBeErr();

--- a/packages/safe-fn/src/types.ts
+++ b/packages/safe-fn/src/types.ts
@@ -159,29 +159,29 @@ export type SchemaOutputOrFallback<TSchema extends SafeFnOutput, TFallback> = [
 */
 
 /**
- * Convenience type for any thrown handler result.
+ * Convenience type for any catch handler result.
  */
-export type AnySafeFnThrownHandlerRes = Result<never, any>;
+export type AnySafeFnCatchHandlerRes = Result<never, any>;
 
 /**
- * Convenience type for any thrown handler function.
+ * Convenience type for any catch handler function.
  */
-export type AnySafeFnThrownHandler = (
+export type AnySafeFnCatchHandler = (
   error: unknown,
-) => AnySafeFnThrownHandlerRes;
+) => AnySafeFnCatchHandlerRes;
 
 /**
- * Default throw handler function. Overridden by `error()`
+ * Default catch handler function. Overridden by `catch()`
  */
-export type SafeFnDefaultThrowHandler = (
+export type SafeFnDefaultCatchHandler = (
   error: unknown,
-) => SafeFnDefaultThrownHandlerErr;
+) => SafeFnDefaultCatchHandlerErr;
 
-export type SafeFnDefaultThrownHandlerErr = Err<
+export type SafeFnDefaultCatchHandlerErr = Err<
   never,
   {
     code: "UNCAUGHT_ERROR";
-    cause: "An uncaught error occurred. You can implement a custom error handler by using `error()`";
+    cause: "An uncaught error occurred. You can implement a custom error handler by using `catch()`";
   }
 >;
 
@@ -391,9 +391,9 @@ export type SafeFnReturnData<
  * @param TInputSchema a Zod schema or undefined
  * @param TOutputSchema a Zod schema or undefined
  * @param THandlerRes the return of the handler function
- * @param TThrownHandler the return of the thrown handler
+ * @param TCatchHandlerRes the return of the catch handler
  * @param TAsAction indicates weather the function is run as an action (full error is not typed if true as it's not sent over the wire)
- * @returns the error type of the return value of the safe function after unsuccessful execution. This is a union of all possible error types that can be thrown by the safe function consisting off:
+ * @returns the error type of the return value of the safe function after unsuccessful execution. This is a union of all possible error types that can be catch by the safe function consisting off:
  * - A union of all `Err` returns of the handler function
  * - A union of all `Err` returns of the uncaught error handler
  * - A `SafeFnInputParseError` if the input schema is defined and the input could not be parsed
@@ -403,11 +403,11 @@ export type SafeFnReturnError<
   TInputSchema extends SafeFnInput,
   TOutputSchema extends SafeFnOutput,
   THandlerRes extends AnySafeFnHandlerRes,
-  TThrownHandlerRes extends AnySafeFnThrownHandlerRes,
+  TCatchHandlerRes extends AnySafeFnCatchHandlerRes,
   TAsAction extends boolean = false,
 > =
   | InferErrError<THandlerRes>
-  | InferErrError<TThrownHandlerRes>
+  | InferErrError<TCatchHandlerRes>
   | SafeFnInputParseError<TInputSchema, TAsAction>
   | SafeFnOutputParseError<TOutputSchema, TAsAction>;
 
@@ -434,7 +434,7 @@ export type SafeFnRunArgs<
  * @param TInputSchema a Zod schema or undefined
  * @param TOutputSchema a Zod schema or undefined
  * @param THandlerRes the return of the handler function
- * @param TThrownHandlerRes the return of the thrown handler
+ * @param TCatchHandlerRes the return of the catch handler
  * @param TAsAction indicates weather the function is run as an action (full error is not typed if true as it's not sent over the wire)
  * @returns the returned value of the safe function after execution without throwing. This is a `ResultAsync` type that can either be an `Ok` or an `Err`.
  *
@@ -443,7 +443,7 @@ export type SafeFnReturn<
   TInputSchema extends SafeFnInput,
   TOutputSchema extends SafeFnOutput,
   THandlerRes extends AnySafeFnHandlerRes,
-  TThrownHandlerRes extends AnySafeFnThrownHandlerRes,
+  TCatchHandlerRes extends AnySafeFnCatchHandlerRes,
   TAsAction extends boolean,
 > =
   Awaited<THandlerRes> extends Result<never, any>
@@ -454,7 +454,7 @@ export type SafeFnReturn<
             TInputSchema,
             undefined,
             Awaited<THandlerRes>,
-            TThrownHandlerRes,
+            TCatchHandlerRes,
             TAsAction
           >
         >
@@ -466,7 +466,7 @@ export type SafeFnReturn<
             TInputSchema,
             TOutputSchema,
             Awaited<THandlerRes>,
-            TThrownHandlerRes,
+            TCatchHandlerRes,
             TAsAction
           >
         >
@@ -523,15 +523,9 @@ export type SafeFnActionReturn<
   TInputSchema extends SafeFnInput,
   TOutputSchema extends SafeFnOutput,
   THandlerRes extends AnySafeFnHandlerRes,
-  TThrownHandlerRes extends AnySafeFnThrownHandlerRes,
+  TCatchHandlerRes extends AnySafeFnCatchHandlerRes,
 > = ResultAsyncToPromiseActionResult<
-  SafeFnReturn<
-    TInputSchema,
-    TOutputSchema,
-    THandlerRes,
-    TThrownHandlerRes,
-    true
-  >
+  SafeFnReturn<TInputSchema, TOutputSchema, THandlerRes, TCatchHandlerRes, true>
 >;
 export type SafeFnAction<
   TParent extends AnyRunnableSafeFn | undefined,
@@ -539,12 +533,12 @@ export type SafeFnAction<
   TOutputSchema extends SafeFnOutput,
   TUnparsedInput,
   THandlerRes extends AnySafeFnHandlerRes,
-  TThrownHandlerRes extends AnySafeFnThrownHandlerRes,
+  TCatchHandlerRes extends AnySafeFnCatchHandlerRes,
 > = (
   ...args: SafeFnActionArgs<TUnparsedInput, TParent>
 ) => SafeFnActionReturn<
   TInputSchema,
   TOutputSchema,
   THandlerRes,
-  TThrownHandlerRes
+  TCatchHandlerRes
 >;


### PR DESCRIPTION
Renames the `.error()` method on the builder to `.catch()` to better signify what it does (catch uncaught errors, it's not called when an `Err` is returned).