### PR TITLE
Rename unparsed input

### DIFF
--- a/packages/safe-fn/src/runnable-safe-fn.ts
+++ b/packages/safe-fn/src/runnable-safe-fn.ts
@@ -13,6 +13,7 @@ import type {
   SafeFnAction,
   SafeFnActionArgs,
   SafeFnActionReturn,
+  SafeFnHandlerArgs,
   SafeFnInput,
   SafeFnInputParseError,
   SafeFnInternals,
@@ -159,10 +160,10 @@ export class RunnableSafeFn<
 
       const handlerRes = yield* (
         await handler({
-          parsedInput,
-          unparsedInput: args,
+          input: parsedInput,
+          unsafeRawInput: args,
           ctx: parentHandlerRes,
-        } as any)
+        } as SafeFnHandlerArgs<TInputSchema, TUnparsedInput, TParent>)
       ).safeUnwrap();
 
       const parsedOutput =

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -48,51 +48,45 @@ describe("SafeFnBuilder", () => {
       test("should properly type parsed and unparsed input for primitives", () => {
         safeFnPrimitiveInput.handler((input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<SchemaPrimitiveInput>();
-          expectTypeOf(
-            input.parsedInput,
-          ).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
         });
 
         safeFnPrimitiveInput.handler(async (input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<SchemaPrimitiveInput>();
-          expectTypeOf(
-            input.parsedInput,
-          ).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
         });
 
         safeFnPrimitiveInput.safeHandler(async function* (input) {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<SchemaPrimitiveInput>();
-          expectTypeOf(
-            input.parsedInput,
-          ).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
         });
       });
 
       test("should properly type parsed and unparsed input for objects", () => {
         safeFnObjectInput.handler((input) => {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<SchemaObjectInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<SchemaObjectInput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
         });
 
         safeFnObjectInput.handler(async (input) => {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<SchemaObjectInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<SchemaObjectInput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
         });
 
         safeFnObjectInput.safeHandler(async function* (input) {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<SchemaObjectInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<SchemaObjectInput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
         });
       });
@@ -100,68 +94,62 @@ describe("SafeFnBuilder", () => {
       test("should properly type parsed and unparsed input for transformed schemas", () => {
         safeFnTransformedInput.handler((input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<SchemaTransformedInput>();
-          expectTypeOf(
-            input.parsedInput,
-          ).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
         });
 
         safeFnTransformedInput.handler(async (input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<SchemaTransformedInput>();
-          expectTypeOf(
-            input.parsedInput,
-          ).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
         });
 
         safeFnTransformedInput.safeHandler(async function* (input) {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<SchemaTransformedInput>();
-          expectTypeOf(
-            input.parsedInput,
-          ).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(input.input).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
         });
       });
 
       test("should type parsedInput as undefined, unparsed input as never when no input schema is provided", () => {
         safeFnNoInput.handler((input) => {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<never>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<undefined>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<never>();
+          expectTypeOf(input.input).toEqualTypeOf<undefined>();
           return ok(input);
         });
 
         safeFnNoInput.handler(async (input) => {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<never>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<undefined>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<never>();
+          expectTypeOf(input.input).toEqualTypeOf<undefined>();
           return ok(input);
         });
 
         safeFnNoInput.safeHandler(async function* (input) {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<never>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<undefined>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<never>();
+          expectTypeOf(input.input).toEqualTypeOf<undefined>();
           return ok(input);
         });
       });
 
       test("should properly type unparsed input when manually set", () => {
         safeFnUnparsedInput.handler((input) => {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<{ name: string }>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<{ name: string }>();
           return ok(input);
         });
 
         safeFnUnparsedInput.handler(async (input) => {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<{ name: string }>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<{ name: string }>();
           return ok(input);
         });
 
         safeFnUnparsedInput.safeHandler(async function* (input) {
-          expectTypeOf(input.unparsedInput).toEqualTypeOf<{ name: string }>();
+          expectTypeOf(input.unsafeRawInput).toEqualTypeOf<{ name: string }>();
           return ok(input);
         });
       });
@@ -184,25 +172,25 @@ describe("SafeFnBuilder", () => {
 
         child.handler((input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.handler(async (input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.safeHandler(async function* (input) {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
       });
@@ -227,25 +215,25 @@ describe("SafeFnBuilder", () => {
 
         child.handler((input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.handler(async (input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.safeHandler(async function* (input) {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
       });
@@ -273,25 +261,25 @@ describe("SafeFnBuilder", () => {
 
         child.handler((input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.handler(async (input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.safeHandler(async function* (input) {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
       });
@@ -305,25 +293,25 @@ describe("SafeFnBuilder", () => {
 
         child.handler((input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.handler(async (input) => {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
 
         child.safeHandler(async function* (input) {
           expectTypeOf(
-            input.unparsedInput,
+            input.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.parsedInput).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
           return ok(input);
         });
       });

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -300,7 +300,7 @@ describe("runnable-safe-fn", () => {
             SafeFnBuilder.new()
               .unparsedInput<{ name: string; lastName: string }>()
               .output(outputSchema)
-              .handler((args) => ok(args.unparsedInput)),
+              .handler((args) => ok(args.unsafeRawInput)),
         },
         {
           name: "async",
@@ -308,7 +308,7 @@ describe("runnable-safe-fn", () => {
             SafeFnBuilder.new()
               .unparsedInput<{ name: string; lastName: string }>()
               .output(outputSchema)
-              .handler(async (args) => ok(args.unparsedInput)),
+              .handler(async (args) => ok(args.unsafeRawInput)),
         },
         {
           name: "generator",
@@ -317,7 +317,7 @@ describe("runnable-safe-fn", () => {
               .unparsedInput<{ name: string; lastName: string }>()
               .output(outputSchema)
               .safeHandler(async function* (args) {
-                return ok(args.unparsedInput);
+                return ok(args.unsafeRawInput);
               }),
         },
       ];
@@ -328,14 +328,14 @@ describe("runnable-safe-fn", () => {
           createSafeFn: () =>
             SafeFnBuilder.new()
               .unparsedInput<{ name: string; lastName: string }>()
-              .handler((args) => ok(args.unparsedInput)),
+              .handler((args) => ok(args.unsafeRawInput)),
         },
         {
           name: "async",
           createSafeFn: () =>
             SafeFnBuilder.new()
               .unparsedInput<{ name: string; lastName: string }>()
-              .handler(async (args) => ok(args.unparsedInput)),
+              .handler(async (args) => ok(args.unsafeRawInput)),
         },
         {
           name: "generator",
@@ -343,7 +343,7 @@ describe("runnable-safe-fn", () => {
             SafeFnBuilder.new()
               .unparsedInput<{ name: string; lastName: string }>()
               .safeHandler(async function* (args) {
-                return ok(args.unparsedInput);
+                return ok(args.unsafeRawInput);
               }),
         },
       ];

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -96,7 +96,7 @@ describe("safe-fn-builder", () => {
     });
   });
 
-  describe("unparsedInput", () => {
+  describe("unsafeRawInput", () => {
     test("should return the same instance", () => {
       const builder = SafeFnBuilder.new();
       const builder2 = builder.unparsedInput<string>();
@@ -229,7 +229,7 @@ describe("runnable-safe-fn", () => {
           expect(res).toBeOk();
           assert(res.isOk());
           expect(res.value).toMatchObject({
-            parsedInput: {
+            input: {
               fullName: "John Doe",
             },
           });
@@ -241,7 +241,7 @@ describe("runnable-safe-fn", () => {
           assert(res.isOk());
           console.log(res.value);
           expect(res.value).toMatchObject({
-            unparsedInput: {
+            unsafeRawInput: {
               name: "John",
               lastName: "Doe",
             },
@@ -270,7 +270,7 @@ describe("runnable-safe-fn", () => {
           expect(res).toBeOk();
           assert(res.isOk());
           expect(res.value).toEqual({
-            unparsedInput: { name: "John", lastName: "Doe" },
+            unsafeRawInput: { name: "John", lastName: "Doe" },
           });
         });
 
@@ -683,11 +683,11 @@ describe("runnable-safe-fn", () => {
       assert(res.isOk());
       expect(res.value).toEqual({
         ctx: "ctx",
-        parsedInput: {
+        input: {
           parsed1: "parsed1",
           parsed3: "parsed3",
         },
-        unparsedInput: {
+        unsafeRawInput: {
           parsed1: "parsed1",
           unparsed2: "unparsed2",
           parsed3: "parsed3",

--- a/packages/safe-fn/src/types.ts
+++ b/packages/safe-fn/src/types.ts
@@ -267,7 +267,7 @@ type SafeFnHandlerArgsWParent<
   TUnparsedInput,
   TParent extends AnyRunnableSafeFn,
 > = {
-  parsedInput: Prettify<
+  input: Prettify<
     UnionIfNotT<
       SchemaOutputOrFallback<TInputSchema, undefined>,
       SchemaOutputOrFallback<InferInputSchema<TParent>, undefined>,
@@ -275,7 +275,7 @@ type SafeFnHandlerArgsWParent<
     >
   >;
   // Prettify<unknown> results in {}
-  unparsedInput: UnionIfNotT<
+  unsafeRawInput: UnionIfNotT<
     TUnparsedInput,
     InferUnparsedInput<TParent>,
     never
@@ -292,8 +292,8 @@ type SafeFnHandlerArgsNoParent<
   TInputSchema extends SafeFnInput,
   TUnparsedInput,
 > = {
-  parsedInput: SchemaOutputOrFallback<TInputSchema, undefined>;
-  unparsedInput: TUnparsedInput;
+  input: SchemaOutputOrFallback<TInputSchema, undefined>;
+  unsafeRawInput: TUnparsedInput;
   ctx: undefined;
 };
 

--- a/packages/safe-fn/src/types.ts
+++ b/packages/safe-fn/src/types.ts
@@ -275,6 +275,11 @@ type SafeFnHandlerArgsWParent<
     >
   >;
   // Prettify<unknown> results in {}
+  /**
+   * The raw input passed to the handler function.
+   *
+   *  **WARNING**: this can have excess values that are not in the type when you use this SafeFn as a parent for another SafeFn.
+   */
   unsafeRawInput: UnionIfNotT<
     TUnparsedInput,
     InferUnparsedInput<TParent>,
@@ -293,6 +298,12 @@ type SafeFnHandlerArgsNoParent<
   TUnparsedInput,
 > = {
   input: SchemaOutputOrFallback<TInputSchema, undefined>;
+  /**
+   * The raw input passed to the handler function.
+   *
+   *  **WARNING**: this can have excess values that are not in the type when you use this SafeFn as a parent for another SafeFn.
+
+   */
   unsafeRawInput: TUnparsedInput;
   ctx: undefined;
 };


### PR DESCRIPTION
Renames arguments of handler functions

- parsedInput -> input (for brevity's sake) 
- unparsedInput -> unsafeRawInput (to signal this should be used carefully as it can have excess props when function is used as a parent) 

Also added JSDoc to highlight the last point. 