### PR TITLE
Create methods

### DIFF
--- a/packages/safe-fn/src/index.ts
+++ b/packages/safe-fn/src/index.ts
@@ -8,7 +8,7 @@ import {
   type InferActionErrError,
   type InferActionOkData,
 } from "./result";
-import { SafeFnBuilder } from "./safe-fn-builder";
+import { createSafeFn } from "./safe-fn-builder";
 
 import type { AnyRunnableSafeFn } from "./runnable-safe-fn";
 
@@ -31,7 +31,7 @@ import type {
   InferUnparsedInput,
 } from "./types/schema";
 
-export { actionResultToResult, SafeFnBuilder as SafeFn };
+export { actionResultToResult, createSafeFn };
 export type {
   ActionErr,
   ActionOk,

--- a/packages/safe-fn/src/safe-fn-builder.ts
+++ b/packages/safe-fn/src/safe-fn-builder.ts
@@ -22,6 +22,9 @@ import type {
 
 import type { TMaybePromise, TPrettify, TUnionIfNotT } from "./types/util";
 
+export const createSafeFn = () => {
+  return SafeFnBuilder.new();
+};
 export class SafeFnBuilder<
   TParent extends AnyRunnableSafeFn | undefined,
   TInputSchema extends TSafeFnInput,
@@ -55,16 +58,9 @@ export class SafeFnBuilder<
 ||                            ||
 ################################
 */
-  static new<TNewParent extends AnyRunnableSafeFn | undefined = undefined>(
-    parent?: TNewParent,
-  ): SafeFnBuilder<
-    TNewParent,
-    undefined,
-    undefined,
-    InferUnparsedInput<TNewParent>
-  > {
+  static new(): SafeFnBuilder<undefined, undefined, undefined, never> {
     return new SafeFnBuilder({
-      parent,
+      parent: undefined,
       inputSchema: undefined,
       outputSchema: undefined,
       handler: (() =>
@@ -80,6 +76,20 @@ export class SafeFnBuilder<
             "An uncaught error occurred. You can implement a custom error handler by using `catch()`",
         } as const);
       }) satisfies TSafeFnDefaultCatchHandler,
+    }) as any;
+  }
+
+  use<TNewParent extends AnyRunnableSafeFn>(
+    parent: TNewParent,
+  ): SafeFnBuilder<
+    TNewParent,
+    TInputSchema,
+    TOutputSchema,
+    InferUnparsedInput<TNewParent>
+  > {
+    return new SafeFnBuilder({
+      ...this._internals,
+      parent: parent as any,
     }) as any;
   }
 

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -161,7 +161,7 @@ describe("SafeFnBuilder", () => {
         });
         const parent = safeFnTransformedInput.handler(() => ok(""));
 
-        const child = SafeFnBuilder.new(parent).input(input2);
+        const child = SafeFnBuilder.new().use(parent).input(input2);
 
         type ExpectedUnparsedInput = TPrettify<
           SchemaTransformedInput & z.input<typeof input2>
@@ -203,7 +203,7 @@ describe("SafeFnBuilder", () => {
           }>()
           .handler(() => ok(""));
 
-        const child = SafeFnBuilder.new(parent).input(schemaTransformed);
+        const child = SafeFnBuilder.new().use(parent).input(schemaTransformed);
 
         type ExpectedUnparsedInput = TPrettify<
           SchemaTransformedInput & {
@@ -246,7 +246,7 @@ describe("SafeFnBuilder", () => {
           }>()
           .handler(() => ok(""));
 
-        const child = SafeFnBuilder.new(parent).unparsedInput<{
+        const child = SafeFnBuilder.new().use(parent).unparsedInput<{
           superNew: string;
           supertest: number[];
         }>();
@@ -286,7 +286,7 @@ describe("SafeFnBuilder", () => {
 
       test("should type unparsedInput as never and parsedInput as undefined when no input schema is provided", () => {
         const parent = SafeFnBuilder.new().handler(() => ok(""));
-        const child = SafeFnBuilder.new(parent);
+        const child = SafeFnBuilder.new().use(parent);
 
         type ExpectedUnparsedInput = never;
         type ExpectedParsedInput = undefined;
@@ -350,7 +350,7 @@ describe("SafeFnBuilder", () => {
             return ok("hello");
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new(syncParent);
+        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
@@ -366,7 +366,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new(asyncParent);
+        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
@@ -377,7 +377,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new(safeParent);
+        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
@@ -407,7 +407,7 @@ describe("SafeFnBuilder", () => {
             return ok({ test: "hello", nested: { value: 1 } });
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new(syncParent);
+        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
@@ -423,7 +423,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new(asyncParent);
+        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
@@ -438,7 +438,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new(safeParent);
+        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
@@ -468,7 +468,7 @@ describe("SafeFnBuilder", () => {
             return ok({ test: "hello", nested: { value: 1 } });
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new(syncParent);
+        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
@@ -484,7 +484,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new(asyncParent);
+        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
@@ -499,7 +499,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new(safeParent);
+        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
@@ -528,7 +528,7 @@ describe("SafeFnBuilder", () => {
           return expectedOutput;
         });
 
-        const safeFnSyncParent = SafeFnBuilder.new(syncParent);
+        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(input);
@@ -542,7 +542,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new(asyncParent);
+        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(input);
@@ -556,7 +556,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new(safeParent);
+        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(input);
@@ -595,9 +595,9 @@ describe("runnableSafeFn", () => {
         const parent = SafeFnBuilder.new()
           .input(schemaTransformed)
           .handler(() => ok("hello" as const));
-        const child = SafeFnBuilder.new(parent).handler(() =>
-          ok("hello" as const),
-        );
+        const child = SafeFnBuilder.new()
+          .use(parent)
+          .handler(() => ok("hello" as const));
 
         expectTypeOf(child.run).parameters.toEqualTypeOf<
           [SchemaTransformedInput]
@@ -848,17 +848,17 @@ describe("runnableSafeFn", () => {
           })
           .catch(() => err("world" as const));
 
-        const safeFnSyncParentSync = SafeFnBuilder.new(parentSync).handler(() =>
-          ok("ok" as const),
-        );
-        const safeFnAsyncParentSync = SafeFnBuilder.new(parentAsync).handler(
-          async () => ok("ok" as const),
-        );
-        const safeFnSafeParentSync = SafeFnBuilder.new(parentSafe).safeHandler(
-          async function* () {
+        const safeFnSyncParentSync = SafeFnBuilder.new()
+          .use(parentSync)
+          .handler(() => ok("ok" as const));
+        const safeFnAsyncParentSync = SafeFnBuilder.new()
+          .use(parentAsync)
+          .handler(async () => ok("ok" as const));
+        const safeFnSafeParentSync = SafeFnBuilder.new()
+          .use(parentSafe)
+          .safeHandler(async function* () {
             return ok("ok" as const);
-          },
-        );
+          });
 
         const resSync = await safeFnSyncParentSync.run();
         const resAsync = await safeFnAsyncParentSync.run();
@@ -893,17 +893,17 @@ describe("runnableSafeFn", () => {
             return ok("hi" as const);
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new(parentSync).handler(() =>
-          ok("ok" as const),
-        );
-        const safeFnAsyncParent = SafeFnBuilder.new(parentAsync).handler(
-          async () => ok("ok" as const),
-        );
-        const safeFnSafeParent = SafeFnBuilder.new(parentSafe).safeHandler(
-          async function* () {
+        const safeFnSyncParent = SafeFnBuilder.new()
+          .use(parentSync)
+          .handler(() => ok("ok" as const));
+        const safeFnAsyncParent = SafeFnBuilder.new()
+          .use(parentAsync)
+          .handler(async () => ok("ok" as const));
+        const safeFnSafeParent = SafeFnBuilder.new()
+          .use(parentSafe)
+          .safeHandler(async function* () {
             return ok("ok" as const);
-          },
-        );
+          });
 
         // @ts-expect-error - input is not compatible
         const resSync = await safeFnSyncParent.run();
@@ -938,9 +938,9 @@ describe("runnableSafeFn", () => {
             }
         >();
 
-        const nestedChild = SafeFnBuilder.new(safeFnSafeParent).handler(() =>
-          ok("ok" as const),
-        );
+        const nestedChild = SafeFnBuilder.new()
+          .use(safeFnSafeParent)
+          .handler(() => ok("ok" as const));
         // @ts-expect-error
         const resNestedChildSync = await nestedChild.run();
 
@@ -962,7 +962,8 @@ describe("runnableSafeFn", () => {
         .handler(() => ok("hello" as const));
       const childSchema = z.object({ child: z.string() });
       type ChildSchemaInput = z.input<typeof childSchema>;
-      const child = SafeFnBuilder.new(safeFn)
+      const child = SafeFnBuilder.new()
+        .use(safeFn)
         .input(childSchema)
         .handler(() => ok("world" as const));
 
@@ -1306,17 +1307,17 @@ describe("runnableSafeFn", () => {
             return ok("hi" as const);
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new(parentSync).handler(() =>
-          ok("ok" as const),
-        );
-        const safeFnAsyncParent = SafeFnBuilder.new(parentAsync).handler(
-          async () => ok("ok" as const),
-        );
-        const safeFnSafeParent = SafeFnBuilder.new(parentSafe).safeHandler(
-          async function* () {
+        const safeFnSyncParent = SafeFnBuilder.new()
+          .use(parentSync)
+          .handler(() => ok("ok" as const));
+        const safeFnAsyncParent = SafeFnBuilder.new()
+          .use(parentAsync)
+          .handler(async () => ok("ok" as const));
+        const safeFnSafeParent = SafeFnBuilder.new()
+          .use(parentSafe)
+          .safeHandler(async function* () {
             return ok("ok" as const);
-          },
-        );
+          });
 
         // @ts-expect-error - input is not compatible
         const resSync = await safeFnSyncParent.createAction()();
@@ -1369,9 +1370,9 @@ describe("runnableSafeFn", () => {
             }
         >();
 
-        const nestedChild = SafeFnBuilder.new(safeFnSafeParent).handler(() =>
-          ok("ok" as const),
-        );
+        const nestedChild = SafeFnBuilder.new()
+          .use(safeFnSafeParent)
+          .handler(() => ok("ok" as const));
         // @ts-expect-error
         const resNestedChildSync = await nestedChild.run();
 

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -2,7 +2,7 @@ import { Err, err, Ok, ok, type Result } from "neverthrow";
 import { assert, describe, expectTypeOf, test } from "vitest";
 import { z } from "zod";
 import { type ActionResult } from "./result";
-import { SafeFnBuilder } from "./safe-fn-builder";
+import { createSafeFn } from "./safe-fn-builder";
 import type {
   TSafeFnDefaultCatchHandlerErr,
   TSafeFnInputParseError,
@@ -36,11 +36,11 @@ type SchemaTransformedOutput = z.output<typeof schemaTransformed>;
 
 describe("SafeFnBuilder", () => {
   describe("action", () => {
-    const safeFnPrimitiveInput = SafeFnBuilder.new().input(schemaPrimitive);
-    const safeFnObjectInput = SafeFnBuilder.new().input(schemaObject);
-    const safeFnTransformedInput = SafeFnBuilder.new().input(schemaTransformed);
-    const safeFnNoInput = SafeFnBuilder.new();
-    const safeFnUnparsedInput = SafeFnBuilder.new().unparsedInput<{
+    const safeFnPrimitiveInput = createSafeFn().input(schemaPrimitive);
+    const safeFnObjectInput = createSafeFn().input(schemaObject);
+    const safeFnTransformedInput = createSafeFn().input(schemaTransformed);
+    const safeFnNoInput = createSafeFn();
+    const safeFnUnparsedInput = createSafeFn().unparsedInput<{
       name: string;
     }>();
 
@@ -161,7 +161,7 @@ describe("SafeFnBuilder", () => {
         });
         const parent = safeFnTransformedInput.handler(() => ok(""));
 
-        const child = SafeFnBuilder.new().use(parent).input(input2);
+        const child = createSafeFn().use(parent).input(input2);
 
         type ExpectedUnparsedInput = TPrettify<
           SchemaTransformedInput & z.input<typeof input2>
@@ -196,14 +196,14 @@ describe("SafeFnBuilder", () => {
       });
 
       test("should merge unparsedInput and type parsedInput from child when parent ha no input schema but defines unparsed", () => {
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .unparsedInput<{
             new: string;
             properties: number[];
           }>()
           .handler(() => ok(""));
 
-        const child = SafeFnBuilder.new().use(parent).input(schemaTransformed);
+        const child = createSafeFn().use(parent).input(schemaTransformed);
 
         type ExpectedUnparsedInput = TPrettify<
           SchemaTransformedInput & {
@@ -239,14 +239,14 @@ describe("SafeFnBuilder", () => {
       });
 
       test("should merge unparsedInput and type parsedInput as undefined when both manually define unparsedInput", () => {
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .unparsedInput<{
             new: string;
             properties: number[];
           }>()
           .handler(() => ok(""));
 
-        const child = SafeFnBuilder.new().use(parent).unparsedInput<{
+        const child = createSafeFn().use(parent).unparsedInput<{
           superNew: string;
           supertest: number[];
         }>();
@@ -285,8 +285,8 @@ describe("SafeFnBuilder", () => {
       });
 
       test("should type unparsedInput as never and parsedInput as undefined when no input schema is provided", () => {
-        const parent = SafeFnBuilder.new().handler(() => ok(""));
-        const child = SafeFnBuilder.new().use(parent);
+        const parent = createSafeFn().handler(() => ok(""));
+        const child = createSafeFn().use(parent);
 
         type ExpectedUnparsedInput = never;
         type ExpectedParsedInput = undefined;
@@ -319,7 +319,7 @@ describe("SafeFnBuilder", () => {
 
     describe("ctx", () => {
       test("should type as undefined when no parent is provided", () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
 
         safeFn.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<undefined>();
@@ -338,19 +338,19 @@ describe("SafeFnBuilder", () => {
       });
 
       describe("should type when parent has primitive output schema", () => {
-        const syncParent = SafeFnBuilder.new()
+        const syncParent = createSafeFn()
           .output(schemaPrimitive)
           .handler(() => ok("hello"));
-        const asyncParent = SafeFnBuilder.new()
+        const asyncParent = createSafeFn()
           .output(schemaPrimitive)
           .handler(async () => ok("hello"));
-        const safeParent = SafeFnBuilder.new()
+        const safeParent = createSafeFn()
           .output(schemaPrimitive)
           .safeHandler(async function* () {
             return ok("hello");
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
+        const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
@@ -366,7 +366,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
+        const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
@@ -377,7 +377,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
+        const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(input);
@@ -395,19 +395,19 @@ describe("SafeFnBuilder", () => {
       });
 
       describe("should type when parent has object output schema", () => {
-        const syncParent = SafeFnBuilder.new()
+        const syncParent = createSafeFn()
           .output(schemaObject)
           .handler(() => ok({ test: "hello", nested: { value: 1 } }));
-        const asyncParent = SafeFnBuilder.new()
+        const asyncParent = createSafeFn()
           .output(schemaObject)
           .handler(async () => ok({ test: "hello", nested: { value: 1 } }));
-        const safeParent = SafeFnBuilder.new()
+        const safeParent = createSafeFn()
           .output(schemaObject)
           .safeHandler(async function* () {
             return ok({ test: "hello", nested: { value: 1 } });
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
+        const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
@@ -423,7 +423,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
+        const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
@@ -438,7 +438,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
+        const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(input);
@@ -456,19 +456,19 @@ describe("SafeFnBuilder", () => {
       });
 
       describe("should properly type when parent has transformed output schema", () => {
-        const syncParent = SafeFnBuilder.new()
+        const syncParent = createSafeFn()
           .output(schemaTransformed)
           .handler(() => ok({ test: "hello", nested: { value: 1 } }));
-        const asyncParent = SafeFnBuilder.new()
+        const asyncParent = createSafeFn()
           .output(schemaTransformed)
           .handler(async () => ok({ test: "hello", nested: { value: 1 } }));
-        const safeParent = SafeFnBuilder.new()
+        const safeParent = createSafeFn()
           .output(schemaTransformed)
           .safeHandler(async function* () {
             return ok({ test: "hello", nested: { value: 1 } });
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
+        const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
@@ -484,7 +484,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
+        const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
@@ -499,7 +499,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
+        const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(input);
@@ -520,15 +520,13 @@ describe("SafeFnBuilder", () => {
         const expectedOutput = ok("hello" as const);
         type ExpectedCtx = "hello";
 
-        const syncParent = SafeFnBuilder.new().handler(() => expectedOutput);
-        const asyncParent = SafeFnBuilder.new().handler(
-          async () => expectedOutput,
-        );
-        const safeParent = SafeFnBuilder.new().safeHandler(async function* () {
+        const syncParent = createSafeFn().handler(() => expectedOutput);
+        const asyncParent = createSafeFn().handler(async () => expectedOutput);
+        const safeParent = createSafeFn().safeHandler(async function* () {
           return expectedOutput;
         });
 
-        const safeFnSyncParent = SafeFnBuilder.new().use(syncParent);
+        const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(input);
@@ -542,7 +540,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnAsyncParent = SafeFnBuilder.new().use(asyncParent);
+        const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(input);
@@ -556,7 +554,7 @@ describe("SafeFnBuilder", () => {
           return ok(input);
         });
 
-        const safeFnSafeParent = SafeFnBuilder.new().use(safeParent);
+        const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((input) => {
           expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(input);
@@ -579,7 +577,7 @@ describe("runnableSafeFn", () => {
   describe("run", () => {
     describe("input", () => {
       test("should not require input when none is set", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn.handler(() => ok("hello" as const));
         const safeFnAsync = safeFn.handler(async () => ok("hello" as const));
         const safeFnSafe = safeFn.safeHandler(async function* () {
@@ -592,10 +590,10 @@ describe("runnableSafeFn", () => {
       });
 
       test("should merge input type from parent", () => {
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .input(schemaTransformed)
           .handler(() => ok("hello" as const));
-        const child = SafeFnBuilder.new()
+        const child = createSafeFn()
           .use(parent)
           .handler(() => ok("hello" as const));
 
@@ -607,7 +605,7 @@ describe("runnableSafeFn", () => {
 
     describe("output", () => {
       test("should type OK as output schema when output schema is provided", async () => {
-        const safeFn = SafeFnBuilder.new().output(schemaTransformed);
+        const safeFn = createSafeFn().output(schemaTransformed);
         const safeFnSync = safeFn.handler(() =>
           ok({ test: "hello", nested: { value: 1 } }),
         );
@@ -634,7 +632,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type Ok as inferred when no output schema is provided", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn.handler(() => ok("hello" as const));
         const safeFnAsync = safeFn.handler(async () => ok("hello" as const));
         const safeFnSafe = safeFn.safeHandler(async function* () {
@@ -655,7 +653,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type Err as default when no catch handler is provided", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn.handler(() => ok("hello" as const));
         const safeFnAsync = safeFn.handler(async () => ok("hello" as const));
         const safeFnSafe = safeFn.safeHandler(async function* () {
@@ -682,7 +680,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type Err as custom when catch handler is provided", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn
           .handler(() => ok("hello" as const))
           .catch(() => err("world" as const));
@@ -709,7 +707,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type Err as inferred when returned from handler", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn.handler(() => err("hello" as const));
         const safeFnAsync = safeFn.handler(async () => err("hello" as const));
         const safeFnSafe = safeFn.safeHandler(async function* () {
@@ -736,7 +734,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should merge errors when both returned and has custom handler", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn
           .handler(() => err("hello" as const))
           .catch(() => err("world" as const));
@@ -763,7 +761,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should correctly type full result when output schema is provided and handler can return only error", async () => {
-        const safeFn = SafeFnBuilder.new().output(schemaTransformed);
+        const safeFn = createSafeFn().output(schemaTransformed);
         const safeFnSync = safeFn.handler(() => err("hello" as const));
         const safeFnAsync = safeFn.handler(async () => err("hello" as const));
         const safeFnSafe = safeFn.safeHandler(async function* () {
@@ -786,7 +784,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should correctly type when handler can return either Err or Ok", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
 
         const safeFnSync = safeFn.handler(() => {
           let bool = true;
@@ -835,7 +833,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should merge Err types from parent handler and catch handler", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const parentSync = safeFn
           .handler(() => err("hello" as const))
           .catch(() => err("world" as const));
@@ -848,13 +846,13 @@ describe("runnableSafeFn", () => {
           })
           .catch(() => err("world" as const));
 
-        const safeFnSyncParentSync = SafeFnBuilder.new()
+        const safeFnSyncParentSync = createSafeFn()
           .use(parentSync)
           .handler(() => ok("ok" as const));
-        const safeFnAsyncParentSync = SafeFnBuilder.new()
+        const safeFnAsyncParentSync = createSafeFn()
           .use(parentAsync)
           .handler(async () => ok("ok" as const));
-        const safeFnSafeParentSync = SafeFnBuilder.new()
+        const safeFnSafeParentSync = createSafeFn()
           .use(parentSafe)
           .safeHandler(async function* () {
             return ok("ok" as const);
@@ -880,7 +878,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should merge Err types from parent schemas", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const parentSync = safeFn
           .input(schemaTransformed)
           .handler(() => ok("hi" as const));
@@ -893,13 +891,13 @@ describe("runnableSafeFn", () => {
             return ok("hi" as const);
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new()
+        const safeFnSyncParent = createSafeFn()
           .use(parentSync)
           .handler(() => ok("ok" as const));
-        const safeFnAsyncParent = SafeFnBuilder.new()
+        const safeFnAsyncParent = createSafeFn()
           .use(parentAsync)
           .handler(async () => ok("ok" as const));
-        const safeFnSafeParent = SafeFnBuilder.new()
+        const safeFnSafeParent = createSafeFn()
           .use(parentSafe)
           .safeHandler(async function* () {
             return ok("ok" as const);
@@ -938,7 +936,7 @@ describe("runnableSafeFn", () => {
             }
         >();
 
-        const nestedChild = SafeFnBuilder.new()
+        const nestedChild = createSafeFn()
           .use(safeFnSafeParent)
           .handler(() => ok("ok" as const));
         // @ts-expect-error
@@ -957,12 +955,12 @@ describe("runnableSafeFn", () => {
     });
 
     describe("callbacks", () => {
-      const safeFn = SafeFnBuilder.new()
+      const safeFn = createSafeFn()
         .input(schemaTransformed)
         .handler(() => ok("hello" as const));
       const childSchema = z.object({ child: z.string() });
       type ChildSchemaInput = z.input<typeof childSchema>;
-      const child = SafeFnBuilder.new()
+      const child = createSafeFn()
         .use(safeFn)
         .input(childSchema)
         .handler(() => ok("world" as const));
@@ -1147,7 +1145,7 @@ describe("runnableSafeFn", () => {
   describe("createAction", () => {
     describe("input", () => {
       test("should not require input when none is set", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn
           .handler(() => ok("hello" as const))
           .createAction();
@@ -1166,7 +1164,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type input when manually set", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn
           .unparsedInput<{ test: string }>()
           .handler((input) => ok(input))
@@ -1190,7 +1188,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type unparsed input as inputSchema for transformed schemas", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn
           .unparsedInput<{ test: string }>()
           .handler((input) => ok(input))
@@ -1198,7 +1196,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should type unparsed input as inputSchema for transformed schemas", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const safeFnSync = safeFn
           .unparsedInput<{ test: string }>()
           .handler((input) => ok(input))
@@ -1225,7 +1223,7 @@ describe("runnableSafeFn", () => {
     describe("output", () => {
       // Just throwing the kitchen sink here to not make this file any longer
       test("should type proper result", async () => {
-        const safeFn = SafeFnBuilder.new()
+        const safeFn = createSafeFn()
           .input(schemaTransformed)
           .output(schemaPrimitive);
 
@@ -1294,7 +1292,7 @@ describe("runnableSafeFn", () => {
       });
 
       test("should merge Err types from parent schemas", async () => {
-        const safeFn = SafeFnBuilder.new();
+        const safeFn = createSafeFn();
         const parentSync = safeFn
           .input(schemaTransformed)
           .handler(() => ok("hi" as const));
@@ -1307,13 +1305,13 @@ describe("runnableSafeFn", () => {
             return ok("hi" as const);
           });
 
-        const safeFnSyncParent = SafeFnBuilder.new()
+        const safeFnSyncParent = createSafeFn()
           .use(parentSync)
           .handler(() => ok("ok" as const));
-        const safeFnAsyncParent = SafeFnBuilder.new()
+        const safeFnAsyncParent = createSafeFn()
           .use(parentAsync)
           .handler(async () => ok("ok" as const));
-        const safeFnSafeParent = SafeFnBuilder.new()
+        const safeFnSafeParent = createSafeFn()
           .use(parentSafe)
           .safeHandler(async function* () {
             return ok("ok" as const);
@@ -1370,7 +1368,7 @@ describe("runnableSafeFn", () => {
             }
         >();
 
-        const nestedChild = SafeFnBuilder.new()
+        const nestedChild = createSafeFn()
           .use(safeFnSafeParent)
           .handler(() => ok("ok" as const));
         // @ts-expect-error

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -2,7 +2,7 @@ import { err, ok, type Result } from "neverthrow";
 import { assert, describe, expect, test, vi, type Mock } from "vitest";
 import { z, ZodError } from "zod";
 import type { AnyRunnableSafeFn } from "./runnable-safe-fn";
-import { SafeFnBuilder } from "./safe-fn-builder";
+import { createSafeFn, SafeFnBuilder } from "./safe-fn-builder";
 import type { TInferSafeFnCallbacks } from "./types/callbacks";
 import type { TODO } from "./types/util";
 
@@ -39,22 +39,22 @@ declare module "vitest" {
 describe("safe-fn-builder", () => {
   describe("new", () => {
     test("should return a builder", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       expect(builder).toBeInstanceOf(SafeFnBuilder);
     });
 
     test("should set the input schema as undefined", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       expect(builder._internals.inputSchema).toBeUndefined();
     });
 
     test("should set the output schema as undefined", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       expect(builder._internals.outputSchema).toBeUndefined();
     });
 
     test("should set the correct default action", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const res = builder._internals.handler(undefined as TODO);
       expect(res).toBeErr();
       // @ts-expect-error - Return not defined in builder type as .run can not be called anyway
@@ -64,7 +64,7 @@ describe("safe-fn-builder", () => {
     });
 
     test("should set the correct default catch handler", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const returnedError = builder._internals.uncaughtErrorHandler(
         undefined as TODO,
       );
@@ -76,22 +76,22 @@ describe("safe-fn-builder", () => {
     });
 
     test("should set the parent safe-fn", () => {
-      const parent = SafeFnBuilder.new().handler(() => ok(""));
-      const child = SafeFnBuilder.new().use(parent);
+      const parent = createSafeFn().handler(() => ok(""));
+      const child = createSafeFn().use(parent);
       expect(child._internals.parent).toBe(parent);
     });
   });
 
   describe("input", () => {
     test("should set the input schema", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const inputSchema = z.string();
       const safeFn = builder.input(inputSchema);
       expect(safeFn._internals.inputSchema).toEqual(inputSchema);
     });
 
     test("should be new instance", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const safeFn = builder.input(z.string());
       const safeFn2 = builder.input(z.string());
       expect(safeFn2).not.toBe(safeFn);
@@ -100,7 +100,7 @@ describe("safe-fn-builder", () => {
 
   describe("unsafeRawInput", () => {
     test("should return the same instance", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const builder2 = builder.unparsedInput<string>();
       expect(builder2).toBe(builder);
     });
@@ -108,14 +108,14 @@ describe("safe-fn-builder", () => {
 
   describe("output", () => {
     test("should set the output schema", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const outputSchema = z.string();
       const safeFn = builder.output(outputSchema);
       expect(safeFn._internals.outputSchema).toEqual(outputSchema);
     });
 
     test("should be new instance", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const safeFn = builder.output(z.string());
       const safeFn2 = builder.output(z.string());
       expect(safeFn2).not.toBe(safeFn);
@@ -124,14 +124,14 @@ describe("safe-fn-builder", () => {
 
   describe("handler", () => {
     test("should set the handler function", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const handlerFn = () => ok("data");
       const safeFn = builder.handler(handlerFn);
       expect(safeFn._internals.handler).toBe(handlerFn);
     });
 
     test("should be new instance", () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const safeFn = builder.handler(() => ok("data"));
       const safeFn2 = builder.handler(() => ok("data"));
       expect(safeFn2).not.toBe(safeFn);
@@ -140,7 +140,7 @@ describe("safe-fn-builder", () => {
 
   describe("safeHandler", () => {
     test("should set the safe handler function", async () => {
-      const builder = SafeFnBuilder.new();
+      const builder = createSafeFn();
       const safeHandlerFn = async function* () {
         return ok("data");
       };
@@ -157,7 +157,7 @@ describe("runnable-safe-fn", () => {
   describe("catch", () => {
     test("should set the catch handler", () => {
       const errorHandler = () => err("error");
-      const safeFn = SafeFnBuilder.new()
+      const safeFn = createSafeFn()
         .handler(() => ok(""))
         .catch(errorHandler);
       expect(safeFn._internals.uncaughtErrorHandler).toEqual(errorHandler);
@@ -176,21 +176,21 @@ describe("runnable-safe-fn", () => {
         {
           name: "regular",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .input(inputSchema)
               .handler((args) => ok(args)),
         },
         {
           name: "async",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .input(inputSchema)
               .handler(async (args) => ok(args)),
         },
         {
           name: "generator",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .input(inputSchema)
               .safeHandler(async function* (args) {
                 return ok(args);
@@ -202,21 +202,21 @@ describe("runnable-safe-fn", () => {
         {
           name: "regular",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<unknown>()
               .handler((args) => ok(args)),
         },
         {
           name: "async",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<unknown>()
               .handler(async (args) => ok(args)),
         },
         {
           name: "generator",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<unknown>()
               .safeHandler(async function* (args) {
                 return ok(args);
@@ -298,7 +298,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "regular",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<{ name: string; lastName: string }>()
               .output(outputSchema)
               .handler((args) => ok(args.unsafeRawInput)),
@@ -306,7 +306,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "async",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<{ name: string; lastName: string }>()
               .output(outputSchema)
               .handler(async (args) => ok(args.unsafeRawInput)),
@@ -314,7 +314,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "generator",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<{ name: string; lastName: string }>()
               .output(outputSchema)
               .safeHandler(async function* (args) {
@@ -327,21 +327,21 @@ describe("runnable-safe-fn", () => {
         {
           name: "regular",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<{ name: string; lastName: string }>()
               .handler((args) => ok(args.unsafeRawInput)),
         },
         {
           name: "async",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<{ name: string; lastName: string }>()
               .handler(async (args) => ok(args.unsafeRawInput)),
         },
         {
           name: "generator",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .unparsedInput<{ name: string; lastName: string }>()
               .safeHandler(async function* (args) {
                 return ok(args.unsafeRawInput);
@@ -392,7 +392,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "regular",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .handler(() => {
                 throw new Error("error");
               })
@@ -406,7 +406,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "async",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .handler(async () => {
                 throw new Error("error");
               })
@@ -420,7 +420,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "generator",
           createSafeFn: () =>
-            SafeFnBuilder.new()
+            createSafeFn()
               .safeHandler(async function* () {
                 throw new Error("error");
               })
@@ -456,7 +456,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "regular",
           createSafeFn: () => {
-            const builder = SafeFnBuilder.new().handler(() => err("Ooh no!"));
+            const builder = createSafeFn().handler(() => err("Ooh no!"));
             builder._parseOutput = outputParseMock;
             return builder;
           },
@@ -464,9 +464,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "async",
           createSafeFn: () => {
-            const builder = SafeFnBuilder.new().handler(async () =>
-              err("Ooh no!"),
-            );
+            const builder = createSafeFn().handler(async () => err("Ooh no!"));
             builder._parseOutput = outputParseMock;
             return builder;
           },
@@ -474,7 +472,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "generator - return error",
           createSafeFn: () => {
-            const builder = SafeFnBuilder.new().safeHandler(async function* () {
+            const builder = createSafeFn().safeHandler(async function* () {
               return err("Ooh no!");
             });
             builder._parseOutput = outputParseMock;
@@ -484,7 +482,7 @@ describe("runnable-safe-fn", () => {
         {
           name: "generator - yield error",
           createSafeFn: () => {
-            const builder = SafeFnBuilder.new().safeHandler(async function* () {
+            const builder = createSafeFn().safeHandler(async function* () {
               yield* err("Ooh no!").safeUnwrap();
               postYieldMock();
               return ok("Ooh yes!");
@@ -531,12 +529,12 @@ describe("runnable-safe-fn", () => {
         };
 
         const parentInputSchema = z.object({ age: z.number() });
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .input(parentInputSchema)
           .handler(() => ok("Parent!" as const));
 
         const childInputSchema = z.object({ name: z.string() });
-        const safeFn = SafeFnBuilder.new()
+        const safeFn = createSafeFn()
           .use(parent)
           .input(childInputSchema)
           .handler(() => ok("Ok!" as const))
@@ -597,11 +595,11 @@ describe("runnable-safe-fn", () => {
         const parentInputSchema = z.object({ age: z.number() });
         const childInputSchema = z.object({ name: z.string() });
 
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .input(parentInputSchema)
           .handler(() => ok("Parent!" as const));
 
-        const safeFn = SafeFnBuilder.new()
+        const safeFn = createSafeFn()
           .use(parent)
           .input(childInputSchema)
           .handler((args) => {
@@ -665,11 +663,11 @@ describe("runnable-safe-fn", () => {
         const parentInputSchema = z.object({ age: z.number() });
         const childInputSchema = z.object({ name: z.string() });
 
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .input(parentInputSchema)
           .handler(() => err("Parent!" as const));
 
-        const safeFn = SafeFnBuilder.new()
+        const safeFn = createSafeFn()
           .use(parent)
           .input(childInputSchema)
           .handler((args) => {
@@ -733,11 +731,11 @@ describe("runnable-safe-fn", () => {
         const parentInputSchema = z.object({ age: z.number() });
         const childInputSchema = z.object({ name: z.string() });
 
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .input(parentInputSchema)
           .handler(() => ok("Parent!" as const));
 
-        const safeFn = SafeFnBuilder.new()
+        const safeFn = createSafeFn()
           .use(parent)
           .input(childInputSchema)
           .handler((args) => {
@@ -805,17 +803,16 @@ describe("runnable-safe-fn", () => {
     const parents = [
       {
         name: "regular",
-        createSafeFn: () => SafeFnBuilder.new().handler((args) => ok("Ok!")),
+        createSafeFn: () => createSafeFn().handler((args) => ok("Ok!")),
       },
       {
         name: "async",
-        createSafeFn: () =>
-          SafeFnBuilder.new().handler(async (args) => ok("Ok!")),
+        createSafeFn: () => createSafeFn().handler(async (args) => ok("Ok!")),
       },
       {
         name: "generator",
         createSafeFn: () =>
-          SafeFnBuilder.new().safeHandler(async function* (args) {
+          createSafeFn().safeHandler(async function* (args) {
             return ok("Ok!");
           }),
       },
@@ -825,21 +822,21 @@ describe("runnable-safe-fn", () => {
       {
         name: "regular",
         createSafeFn: (parent: AnyRunnableSafeFn) =>
-          SafeFnBuilder.new()
+          createSafeFn()
             .use(parent)
             .handler((args) => ok(args.ctx)),
       },
       {
         name: "async",
         createSafeFn: (parent: AnyRunnableSafeFn) =>
-          SafeFnBuilder.new()
+          createSafeFn()
             .use(parent)
             .handler(async (args) => ok(args.ctx)),
       },
       {
         name: "generator",
         createSafeFn: (parent: AnyRunnableSafeFn) =>
-          SafeFnBuilder.new()
+          createSafeFn()
             .use(parent)
             .safeHandler(async function* (args) {
               return ok(args.ctx);
@@ -868,25 +865,24 @@ describe("runnable-safe-fn", () => {
     const parentsWithError = [
       {
         name: "regular",
-        createSafeFn: () =>
-          SafeFnBuilder.new().handler((args) => err("Not ok!")),
+        createSafeFn: () => createSafeFn().handler((args) => err("Not ok!")),
       },
       {
         name: "async",
         createSafeFn: () =>
-          SafeFnBuilder.new().handler(async (args) => err("Not ok!")),
+          createSafeFn().handler(async (args) => err("Not ok!")),
       },
       {
         name: "generator - return error",
         createSafeFn: () =>
-          SafeFnBuilder.new().safeHandler(async function* (args) {
+          createSafeFn().safeHandler(async function* (args) {
             return err("Not ok!");
           }),
       },
       {
         name: "generator - yield error",
         createSafeFn: () =>
-          SafeFnBuilder.new().safeHandler(async function* (args) {
+          createSafeFn().safeHandler(async function* (args) {
             yield* err("Not ok!").safeUnwrap();
             return ok("Ok!");
           }),
@@ -897,19 +893,19 @@ describe("runnable-safe-fn", () => {
       {
         name: "regular",
         createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          SafeFnBuilder.new().use(parent).handler(mockHandler),
+          createSafeFn().use(parent).handler(mockHandler),
       },
       {
         name: "async",
         createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          SafeFnBuilder.new()
+          createSafeFn()
             .use(parent)
             .handler(async () => mockHandler()),
       },
       {
         name: "generator",
         createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          SafeFnBuilder.new()
+          createSafeFn()
             .use(parent)
             .safeHandler(async function* () {
               return mockHandler();
@@ -944,7 +940,7 @@ describe("runnable-safe-fn", () => {
 
     test("should pass parsed and unparsed input from parent to child", async () => {
       // TODO: also do for other types of handlers
-      const fn1 = SafeFnBuilder.new()
+      const fn1 = createSafeFn()
         .input(
           z.object({
             parsed1: z.string(),
@@ -952,11 +948,11 @@ describe("runnable-safe-fn", () => {
         )
         .handler(() => ok(""));
 
-      const fn2 = SafeFnBuilder.new()
+      const fn2 = createSafeFn()
         .use(fn1)
         .unparsedInput<{ unparsed2: string }>()
         .handler(() => ok("ctx"));
-      const fn3 = SafeFnBuilder.new()
+      const fn3 = createSafeFn()
         .use(fn2)
         .input(
           z.object({
@@ -991,7 +987,7 @@ describe("runnable-safe-fn", () => {
   describe("createAction", () => {
     describe("input", async () => {
       test("should transform input error", async () => {
-        const action = SafeFnBuilder.new()
+        const action = createSafeFn()
           .input(z.object({ name: z.string() }))
           .handler((args) => ok(args))
           .createAction();
@@ -1008,10 +1004,10 @@ describe("runnable-safe-fn", () => {
       });
 
       test("should transform input error from parent", async () => {
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .input(z.object({ name: z.string() }))
           .handler((args) => ok(args));
-        const child = SafeFnBuilder.new()
+        const child = createSafeFn()
           .use(parent)
           .input(z.object({ age: z.number() }))
           .handler((args) => ok(args))
@@ -1031,7 +1027,7 @@ describe("runnable-safe-fn", () => {
 
     describe("output", () => {
       test("should transform output error", async () => {
-        const action = SafeFnBuilder.new()
+        const action = createSafeFn()
           .output(z.object({ name: z.string() }))
           // @ts-expect-error - passing wrong input on purpose
           .handler((args) => {
@@ -1050,13 +1046,13 @@ describe("runnable-safe-fn", () => {
       });
 
       test("should transform output error from parent", async () => {
-        const parent = SafeFnBuilder.new()
+        const parent = createSafeFn()
           .output(z.object({ name: z.string() }))
           //@ts-expect-error - passing wrong input on purpose
           .handler((args) => {
             return ok({});
           });
-        const child = SafeFnBuilder.new()
+        const child = createSafeFn()
           .use(parent)
           .handler((args) => ok(args))
           .createAction();
@@ -1072,14 +1068,14 @@ describe("runnable-safe-fn", () => {
         expect(res.error.cause.formattedError).toHaveProperty(["name"]);
         expect(res.error.cause).toHaveProperty(["flattenedError"]);
 
-        const child2 = SafeFnBuilder.new()
+        const child2 = createSafeFn()
           .use(parent)
           .output(z.object({ age: z.number() }))
           .handler(() => {
             return ok({ age: 100 });
           });
 
-        const child3 = SafeFnBuilder.new()
+        const child3 = createSafeFn()
           .use(child2)
           .handler(() => ok({}))
           .createAction();

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -77,7 +77,7 @@ describe("safe-fn-builder", () => {
 
     test("should set the parent safe-fn", () => {
       const parent = SafeFnBuilder.new().handler(() => ok(""));
-      const child = SafeFnBuilder.new(parent);
+      const child = SafeFnBuilder.new().use(parent);
       expect(child._internals.parent).toBe(parent);
     });
   });
@@ -536,7 +536,8 @@ describe("runnable-safe-fn", () => {
           .handler(() => ok("Parent!" as const));
 
         const childInputSchema = z.object({ name: z.string() });
-        const safeFn = SafeFnBuilder.new(parent)
+        const safeFn = SafeFnBuilder.new()
+          .use(parent)
           .input(childInputSchema)
           .handler(() => ok("Ok!" as const))
           .onStart(callbackMocks.onStart)
@@ -600,7 +601,8 @@ describe("runnable-safe-fn", () => {
           .input(parentInputSchema)
           .handler(() => ok("Parent!" as const));
 
-        const safeFn = SafeFnBuilder.new(parent)
+        const safeFn = SafeFnBuilder.new()
+          .use(parent)
           .input(childInputSchema)
           .handler((args) => {
             return err("Woops!");
@@ -667,7 +669,8 @@ describe("runnable-safe-fn", () => {
           .input(parentInputSchema)
           .handler(() => err("Parent!" as const));
 
-        const safeFn = SafeFnBuilder.new(parent)
+        const safeFn = SafeFnBuilder.new()
+          .use(parent)
           .input(childInputSchema)
           .handler((args) => {
             return ok("Child");
@@ -734,7 +737,8 @@ describe("runnable-safe-fn", () => {
           .input(parentInputSchema)
           .handler(() => ok("Parent!" as const));
 
-        const safeFn = SafeFnBuilder.new(parent)
+        const safeFn = SafeFnBuilder.new()
+          .use(parent)
           .input(childInputSchema)
           .handler((args) => {
             return ok("Child");
@@ -821,19 +825,25 @@ describe("runnable-safe-fn", () => {
       {
         name: "regular",
         createSafeFn: (parent: AnyRunnableSafeFn) =>
-          SafeFnBuilder.new(parent).handler((args) => ok(args.ctx)),
+          SafeFnBuilder.new()
+            .use(parent)
+            .handler((args) => ok(args.ctx)),
       },
       {
         name: "async",
         createSafeFn: (parent: AnyRunnableSafeFn) =>
-          SafeFnBuilder.new(parent).handler(async (args) => ok(args.ctx)),
+          SafeFnBuilder.new()
+            .use(parent)
+            .handler(async (args) => ok(args.ctx)),
       },
       {
         name: "generator",
         createSafeFn: (parent: AnyRunnableSafeFn) =>
-          SafeFnBuilder.new(parent).safeHandler(async function* (args) {
-            return ok(args.ctx);
-          }),
+          SafeFnBuilder.new()
+            .use(parent)
+            .safeHandler(async function* (args) {
+              return ok(args.ctx);
+            }),
       },
     ];
 
@@ -887,19 +897,23 @@ describe("runnable-safe-fn", () => {
       {
         name: "regular",
         createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          SafeFnBuilder.new(parent).handler(mockHandler),
+          SafeFnBuilder.new().use(parent).handler(mockHandler),
       },
       {
         name: "async",
         createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          SafeFnBuilder.new(parent).handler(async () => mockHandler()),
+          SafeFnBuilder.new()
+            .use(parent)
+            .handler(async () => mockHandler()),
       },
       {
         name: "generator",
         createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          SafeFnBuilder.new(parent).safeHandler(async function* () {
-            return mockHandler();
-          }),
+          SafeFnBuilder.new()
+            .use(parent)
+            .safeHandler(async function* () {
+              return mockHandler();
+            }),
       },
     ];
     parentsWithError.forEach(
@@ -938,10 +952,12 @@ describe("runnable-safe-fn", () => {
         )
         .handler(() => ok(""));
 
-      const fn2 = SafeFnBuilder.new(fn1)
+      const fn2 = SafeFnBuilder.new()
+        .use(fn1)
         .unparsedInput<{ unparsed2: string }>()
         .handler(() => ok("ctx"));
-      const fn3 = SafeFnBuilder.new(fn2)
+      const fn3 = SafeFnBuilder.new()
+        .use(fn2)
         .input(
           z.object({
             parsed3: z.string(),
@@ -995,7 +1011,8 @@ describe("runnable-safe-fn", () => {
         const parent = SafeFnBuilder.new()
           .input(z.object({ name: z.string() }))
           .handler((args) => ok(args));
-        const child = SafeFnBuilder.new(parent)
+        const child = SafeFnBuilder.new()
+          .use(parent)
           .input(z.object({ age: z.number() }))
           .handler((args) => ok(args))
           .createAction();
@@ -1039,7 +1056,8 @@ describe("runnable-safe-fn", () => {
           .handler((args) => {
             return ok({});
           });
-        const child = SafeFnBuilder.new(parent)
+        const child = SafeFnBuilder.new()
+          .use(parent)
           .handler((args) => ok(args))
           .createAction();
 
@@ -1054,13 +1072,15 @@ describe("runnable-safe-fn", () => {
         expect(res.error.cause.formattedError).toHaveProperty(["name"]);
         expect(res.error.cause).toHaveProperty(["flattenedError"]);
 
-        const child2 = SafeFnBuilder.new(parent)
+        const child2 = SafeFnBuilder.new()
+          .use(parent)
           .output(z.object({ age: z.number() }))
           .handler(() => {
             return ok({ age: 100 });
           });
 
-        const child3 = SafeFnBuilder.new(child2)
+        const child3 = SafeFnBuilder.new()
+          .use(child2)
           .handler(() => ok({}))
           .createAction();
 


### PR DESCRIPTION
- Adds convenient `createSafeFn` method
- moves setting parent to `use()`
- removes old export of the builder