### PR TITLE
Switch from merging parsed input to typed tuple

### DIFF
--- a/packages/safe-fn/src/runnable-safe-fn.ts
+++ b/packages/safe-fn/src/runnable-safe-fn.ts
@@ -446,9 +446,7 @@ export class RunnableSafeFn<
                 .mapErr(
                   (e) =>
                     ({
-                      public: e as THandlerRes extends Result<never, any>
-                        ? never
-                        : TSafeFnOutputParseError<TOutputSchema, TAsAction>,
+                      public: e as any,
                       private: {
                         ctx: {
                           value: ctx.value,

--- a/packages/safe-fn/src/runnable-safe-fn.ts
+++ b/packages/safe-fn/src/runnable-safe-fn.ts
@@ -466,22 +466,6 @@ export class RunnableSafeFn<
           parsedOutput === undefined
             ? (handlerRes as TSafeFnReturnData<TOutputSchema, THandlerRes>)
             : (parsedOutput as TSafeFnReturnData<TOutputSchema, THandlerRes>);
-
-        // console.log(
-        //   JSON.stringify(
-        //     {
-        //       result,
-        //       input: parsedInput,
-        //       ctx: {
-        //         value: ctx.value,
-        //         input: ctx.input as TCtxInput<TParent>,
-        //       },
-        //       unsafeRawInput: args as TUnparsedInput,
-        //     },
-        //     null,
-        //     2,
-        //   ),
-        // );
         return ok({
           result,
           input: parsedInput,

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -154,44 +154,66 @@ describe("SafeFnBuilder", () => {
         });
       });
 
-      test("should merge parsed and unparsed input when parent and child have input schema with transforms", () => {
+      test("should merge unparsed and type array of parsed input when parent and child have input schema with transforms", () => {
         const input2 = z.object({
           new: z.string(),
           properties: z.array(z.number()),
         });
+
+        const input3 = z.object({
+          new2: z.string(),
+          properties2: z.array(z.number()),
+        });
+
         const parent = safeFnTransformedInput.handler(() => ok(""));
 
-        const child = createSafeFn().use(parent).input(input2);
+        const child = createSafeFn()
+          .use(parent)
+          .handler(() => ok(""));
+        const child2 = createSafeFn()
+          .use(child)
+          .input(input2)
+          .handler(() => ok(""));
+        const child3 = createSafeFn().use(child2).input(input3);
 
         type ExpectedUnparsedInput = TPrettify<
-          SchemaTransformedInput & z.input<typeof input2>
+          SchemaTransformedInput &
+            z.input<typeof input2> &
+            z.input<typeof input3>
         >;
-        type ExpectedParsedInput = TPrettify<
-          SchemaTransformedOutput & z.output<typeof input2>
-        >;
+        type ExpectedParsedInput = z.input<typeof input3>;
 
-        child.handler((input) => {
+        type ExpectedCtxInput = [
+          SchemaTransformedOutput,
+          undefined,
+          z.input<typeof input2>,
+        ];
+
+        child3.handler((args) => {
           expectTypeOf(
-            input.unsafeRawInput,
+            args.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
-          return ok(input);
+          expectTypeOf(args.input).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(args.ctx.input).toEqualTypeOf<ExpectedCtxInput>();
+          return ok(args);
         });
 
-        child.handler(async (input) => {
+        child3.handler(async (args) => {
           expectTypeOf(
-            input.unsafeRawInput,
+            args.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
-          return ok(input);
+          expectTypeOf(args.input).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(args.ctx.input).toEqualTypeOf<ExpectedCtxInput>();
+          return ok(args);
         });
 
-        child.safeHandler(async function* (input) {
+        child3.safeHandler(async function* (args) {
           expectTypeOf(
-            input.unsafeRawInput,
+            args.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
-          expectTypeOf(input.input).toEqualTypeOf<ExpectedParsedInput>();
-          return ok(input);
+          expectTypeOf(args.input).toEqualTypeOf<ExpectedParsedInput>();
+          expectTypeOf(args.ctx.input).toEqualTypeOf<ExpectedCtxInput>();
+          return ok(args);
         });
       });
 
@@ -318,26 +340,26 @@ describe("SafeFnBuilder", () => {
     });
 
     describe("ctx", () => {
-      test("should type as undefined when no parent is provided", () => {
+      test("should type value as undefined when no parent is provided", () => {
         const safeFn = createSafeFn();
 
-        safeFn.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<undefined>();
-          return ok(input);
+        safeFn.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<undefined>();
+          return ok(args);
         });
 
-        safeFn.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<undefined>();
-          return ok(input);
+        safeFn.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<undefined>();
+          return ok(args);
         });
 
-        safeFn.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<undefined>();
-          return ok(input);
+        safeFn.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<undefined>();
+          return ok(args);
         });
       });
 
-      describe("should type when parent has primitive output schema", () => {
+      describe("should type value when parent has primitive output schema", () => {
         const syncParent = createSafeFn()
           .output(schemaPrimitive)
           .handler(() => ok("hello"));
@@ -351,50 +373,50 @@ describe("SafeFnBuilder", () => {
           });
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
-        safeFnSyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnSyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
-        safeFnSyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnSyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
-        safeFnSyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnSyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
-        safeFnAsyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnAsyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
-        safeFnAsyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnAsyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
-        safeFnSafeParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnSafeParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
-        safeFnSafeParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnSafeParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
 
-        safeFnSafeParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
-          return ok(input);
+        safeFnSafeParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          return ok(args);
         });
       });
 
-      describe("should type when parent has object output schema", () => {
+      describe("should type value when parent has object output schema", () => {
         const syncParent = createSafeFn()
           .output(schemaObject)
           .handler(() => ok({ test: "hello", nested: { value: 1 } }));
@@ -408,54 +430,54 @@ describe("SafeFnBuilder", () => {
           });
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
-        safeFnSyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnSyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
-        safeFnSyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnSyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
-        safeFnSyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnSyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
-        safeFnAsyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnAsyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
-        safeFnAsyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnAsyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
-        safeFnAsyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnAsyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
-        safeFnSafeParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnSafeParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
-        safeFnSafeParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnSafeParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
 
-        safeFnSafeParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaObjectOutput>();
-          return ok(input);
+        safeFnSafeParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          return ok(args);
         });
       });
 
-      describe("should properly type when parent has transformed output schema", () => {
+      describe("should properly type value when parent has transformed output schema", () => {
         const syncParent = createSafeFn()
           .output(schemaTransformed)
           .handler(() => ok({ test: "hello", nested: { value: 1 } }));
@@ -469,54 +491,54 @@ describe("SafeFnBuilder", () => {
           });
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
-        safeFnSyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnSyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
-        safeFnSyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnSyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
-        safeFnSyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnSyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
-        safeFnAsyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnAsyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
-        safeFnAsyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnAsyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
-        safeFnAsyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnAsyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
-        safeFnSafeParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnSafeParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
-        safeFnSafeParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnSafeParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
 
-        safeFnSafeParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<SchemaTransformedOutput>();
-          return ok(input);
+        safeFnSafeParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          return ok(args);
         });
       });
 
-      describe("should properly type when parent output is inferred", () => {
+      describe("should properly type value when parent output is inferred", () => {
         const expectedOutput = ok("hello" as const);
         type ExpectedCtx = "hello";
 
@@ -527,46 +549,46 @@ describe("SafeFnBuilder", () => {
         });
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
-        safeFnSyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnSyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
-        safeFnSyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnSyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
-        safeFnSyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnSyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
-        safeFnAsyncParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnAsyncParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
-        safeFnAsyncParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnAsyncParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
-        safeFnAsyncParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnAsyncParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
-        safeFnSafeParent.handler((input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnSafeParent.handler((args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
 
-        safeFnSafeParent.handler(async (input) => {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnSafeParent.handler(async (args) => {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
-        safeFnSafeParent.safeHandler(async function* (input) {
-          expectTypeOf(input.ctx).toEqualTypeOf<ExpectedCtx>();
-          return ok(input);
+        safeFnSafeParent.safeHandler(async function* (args) {
+          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          return ok(args);
         });
       });
     });
@@ -986,10 +1008,13 @@ describe("runnableSafeFn", () => {
           SchemaTransformedInput & { child: string }
         >;
 
-        type ExpectedInput =
-          | TPrettify<SchemaTransformedOutput & { child: string }>
+        type ExpectedInput = { child: string } | undefined;
+        type ExpectedCtx =
+          | {
+              value: "hello";
+              input: [SchemaTransformedOutput];
+            }
           | undefined;
-        type ExpectedCtx = "hello" | undefined;
         type ExpectedRunErrError =
           | TSafeFnDefaultCatchHandlerErr["error"]
           | {
@@ -1051,10 +1076,11 @@ describe("runnableSafeFn", () => {
         type ExpectedUnsafeRawInput = TPrettify<
           SchemaTransformedInput & { child: string }
         >;
-        type ExpectedInput = TPrettify<
-          SchemaTransformedOutput & { child: string }
-        >;
-        type ExpectedCtx = "hello";
+        type ExpectedInput = { child: string };
+        type ExpectedCtx = {
+          value: "hello";
+          input: [SchemaTransformedOutput];
+        };
         type ExpectedOkData = "world";
 
         type ExpectedArgs = TPrettify<{
@@ -1075,10 +1101,11 @@ describe("runnableSafeFn", () => {
         type ExpectedUnsafeRawInput = TPrettify<
           SchemaTransformedInput & { child: string }
         >;
-        type ExpectedInput = TPrettify<
-          SchemaTransformedOutput & { child: string }
-        >;
-        type ExpectedCtx = "hello";
+        type ExpectedInput = { child: string };
+        type ExpectedCtx = {
+          value: "hello";
+          input: [SchemaTransformedOutput];
+        };
         type ExpectedOkData = "world";
         type ExpectedRunErrError =
           | TSafeFnDefaultCatchHandlerErr["error"]

--- a/packages/safe-fn/src/safe-fn.test-d.ts
+++ b/packages/safe-fn/src/safe-fn.test-d.ts
@@ -194,7 +194,7 @@ describe("SafeFnBuilder", () => {
             args.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
           expectTypeOf(args.input).toEqualTypeOf<ExpectedParsedInput>();
-          expectTypeOf(args.ctx.input).toEqualTypeOf<ExpectedCtxInput>();
+          expectTypeOf(args.ctxInput).toEqualTypeOf<ExpectedCtxInput>();
           return ok(args);
         });
 
@@ -203,7 +203,7 @@ describe("SafeFnBuilder", () => {
             args.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
           expectTypeOf(args.input).toEqualTypeOf<ExpectedParsedInput>();
-          expectTypeOf(args.ctx.input).toEqualTypeOf<ExpectedCtxInput>();
+          expectTypeOf(args.ctxInput).toEqualTypeOf<ExpectedCtxInput>();
           return ok(args);
         });
 
@@ -212,7 +212,7 @@ describe("SafeFnBuilder", () => {
             args.unsafeRawInput,
           ).toEqualTypeOf<ExpectedUnparsedInput>();
           expectTypeOf(args.input).toEqualTypeOf<ExpectedParsedInput>();
-          expectTypeOf(args.ctx.input).toEqualTypeOf<ExpectedCtxInput>();
+          expectTypeOf(args.ctxInput).toEqualTypeOf<ExpectedCtxInput>();
           return ok(args);
         });
       });
@@ -344,17 +344,17 @@ describe("SafeFnBuilder", () => {
         const safeFn = createSafeFn();
 
         safeFn.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<undefined>();
+          expectTypeOf(args.ctx).toEqualTypeOf<undefined>();
           return ok(args);
         });
 
         safeFn.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<undefined>();
+          expectTypeOf(args.ctx).toEqualTypeOf<undefined>();
           return ok(args);
         });
 
         safeFn.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<undefined>();
+          expectTypeOf(args.ctx).toEqualTypeOf<undefined>();
           return ok(args);
         });
       });
@@ -374,44 +374,44 @@ describe("SafeFnBuilder", () => {
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         safeFnSyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         safeFnSyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         safeFnAsyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         safeFnSafeParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
 
         safeFnSafeParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaPrimitiveOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaPrimitiveOutput>();
           return ok(args);
         });
       });
@@ -431,48 +431,48 @@ describe("SafeFnBuilder", () => {
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         safeFnSyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         safeFnSyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         safeFnAsyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
         safeFnAsyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         safeFnSafeParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
 
         safeFnSafeParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaObjectOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaObjectOutput>();
           return ok(args);
         });
       });
@@ -492,48 +492,48 @@ describe("SafeFnBuilder", () => {
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         safeFnSyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         safeFnSyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         safeFnAsyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
         safeFnAsyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         safeFnSafeParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
 
         safeFnSafeParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<SchemaTransformedOutput>();
+          expectTypeOf(args.ctx).toEqualTypeOf<SchemaTransformedOutput>();
           return ok(args);
         });
       });
@@ -550,44 +550,44 @@ describe("SafeFnBuilder", () => {
 
         const safeFnSyncParent = createSafeFn().use(syncParent);
         safeFnSyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
         safeFnSyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
         safeFnSyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
 
         const safeFnAsyncParent = createSafeFn().use(asyncParent);
         safeFnAsyncParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
         safeFnAsyncParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
         safeFnAsyncParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
 
         const safeFnSafeParent = createSafeFn().use(safeParent);
         safeFnSafeParent.handler((args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
 
         safeFnSafeParent.handler(async (args) => {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
         safeFnSafeParent.safeHandler(async function* (args) {
-          expectTypeOf(args.ctx.value).toEqualTypeOf<ExpectedCtx>();
+          expectTypeOf(args.ctx).toEqualTypeOf<ExpectedCtx>();
           return ok(args);
         });
       });
@@ -1009,12 +1009,8 @@ describe("runnableSafeFn", () => {
         >;
 
         type ExpectedInput = { child: string } | undefined;
-        type ExpectedCtx =
-          | {
-              value: "hello";
-              input: [SchemaTransformedOutput];
-            }
-          | undefined;
+        type ExpectedCtx = "hello" | undefined;
+        type ExpectedCtxInput = [SchemaTransformedOutput] | undefined;
         type ExpectedRunErrError =
           | TSafeFnDefaultCatchHandlerErr["error"]
           | {
@@ -1054,6 +1050,7 @@ describe("runnableSafeFn", () => {
               error: ExpectedActionErrError;
               input: ExpectedInput;
               ctx: ExpectedCtx;
+              ctxInput: ExpectedCtxInput;
               unsafeRawInput: UnsafeRawInput;
             }
           | {
@@ -1061,6 +1058,7 @@ describe("runnableSafeFn", () => {
               error: ExpectedRunErrError;
               input: ExpectedInput;
               ctx: ExpectedCtx;
+              ctxInput: ExpectedCtxInput;
               unsafeRawInput: UnsafeRawInput;
             }
         >;
@@ -1077,16 +1075,15 @@ describe("runnableSafeFn", () => {
           SchemaTransformedInput & { child: string }
         >;
         type ExpectedInput = { child: string };
-        type ExpectedCtx = {
-          value: "hello";
-          input: [SchemaTransformedOutput];
-        };
+        type ExpectedCtx = "hello" | undefined;
+        type ExpectedCtxInput = [SchemaTransformedOutput] | undefined;
         type ExpectedOkData = "world";
 
         type ExpectedArgs = TPrettify<{
           unsafeRawInput: ExpectedUnsafeRawInput;
           input: ExpectedInput;
           ctx: ExpectedCtx;
+          ctxInput: ExpectedCtxInput;
           value: ExpectedOkData;
         }>;
 
@@ -1102,10 +1099,8 @@ describe("runnableSafeFn", () => {
           SchemaTransformedInput & { child: string }
         >;
         type ExpectedInput = { child: string };
-        type ExpectedCtx = {
-          value: "hello";
-          input: [SchemaTransformedOutput];
-        };
+        type ExpectedCtx = "hello";
+        type ExpectedCtxInput = [SchemaTransformedOutput];
         type ExpectedOkData = "world";
         type ExpectedRunErrError =
           | TSafeFnDefaultCatchHandlerErr["error"]
@@ -1147,6 +1142,7 @@ describe("runnableSafeFn", () => {
               unsafeRawInput: ExpectedUnsafeRawInput;
               input: ExpectedInput;
               ctx: ExpectedCtx;
+              ctxInput: ExpectedCtxInput;
               result: Ok<ExpectedOkData, never>;
             }
           | {
@@ -1154,6 +1150,7 @@ describe("runnableSafeFn", () => {
               unsafeRawInput: ExpectedUnsafeRawInput;
               input: ExpectedInput | undefined;
               ctx: ExpectedCtx | undefined;
+              ctxInput: ExpectedCtxInput | undefined;
               result: Err<never, ExpectedActionErrError>;
             }
           | {
@@ -1161,6 +1158,7 @@ describe("runnableSafeFn", () => {
               unsafeRawInput: ExpectedUnsafeRawInput;
               input: ExpectedInput | undefined;
               ctx: ExpectedCtx | undefined;
+              ctxInput: ExpectedCtxInput | undefined;
               result: Err<never, ExpectedRunErrError>;
             }
         >;

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -175,25 +175,23 @@ describe("runnable-safe-fn", () => {
       const testCasesWithInputSchema = [
         {
           name: "regular",
-          createSafeFn: () =>
-            createSafeFn()
-              .input(inputSchema)
-              .handler((args) => ok(args)),
+          createMockFn: (mockAction: Mock) =>
+            createSafeFn().input(inputSchema).handler(mockAction),
         },
         {
           name: "async",
-          createSafeFn: () =>
+          createMockFn: (mockAction: Mock) =>
             createSafeFn()
               .input(inputSchema)
-              .handler(async (args) => ok(args)),
+              .handler(async (args) => mockAction(args)),
         },
         {
           name: "generator",
-          createSafeFn: () =>
+          createMockFn: (mockAction: Mock) =>
             createSafeFn()
               .input(inputSchema)
               .safeHandler(async function* (args) {
-                return ok(args);
+                return mockAction(args);
               }),
         },
       ];
@@ -201,59 +199,61 @@ describe("runnable-safe-fn", () => {
       const testCasesWithoutInputSchema = [
         {
           name: "regular",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<unknown>()
-              .handler((args) => ok(args)),
+          createMockFn: (mockAction: Mock) =>
+            createSafeFn().unparsedInput<unknown>().handler(mockAction),
         },
         {
           name: "async",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<unknown>()
-              .handler(async (args) => ok(args)),
+          createMockFn: (mockAction: Mock) =>
+            createSafeFn().unparsedInput<unknown>().handler(mockAction),
         },
         {
           name: "generator",
-          createSafeFn: () =>
+          createMockFn: (mockAction: Mock) =>
             createSafeFn()
               .unparsedInput<unknown>()
               .safeHandler(async function* (args) {
-                return ok(args);
+                return mockAction(args);
               }),
         },
       ];
 
-      testCasesWithInputSchema.forEach(({ name, createSafeFn }) => {
+      testCasesWithInputSchema.forEach(({ name, createMockFn }) => {
         test(`should parse input and pass it to ${name} handler when input schema is defined`, async () => {
-          const safeFn = createSafeFn();
+          const mock = vi.fn().mockResolvedValue(ok(""));
+          const safeFn = createMockFn(mock);
           const res = await safeFn.run({ name: "John", lastName: "Doe" });
           expect(res).toBeOk();
-          assert(res.isOk());
-          expect(res.value).toMatchObject({
-            input: {
-              fullName: "John Doe",
-            },
+          const args = mock.mock.calls[0]![0];
+          expect(args.input).toEqual({
+            fullName: "John Doe",
+          });
+          expect(args.unsafeRawInput).toEqual({
+            name: "John",
+            lastName: "Doe",
           });
         });
         test("should pass unparsed input to handler when input schema is defined", async () => {
-          const safeFn = createSafeFn();
+          const mock = vi.fn().mockResolvedValue(ok(""));
+          const safeFn = createMockFn(mock);
           const res = await safeFn.run({ name: "John", lastName: "Doe" });
           expect(res).toBeOk();
-          assert(res.isOk());
-          expect(res.value).toMatchObject({
-            unsafeRawInput: {
-              name: "John",
-              lastName: "Doe",
-            },
+          const args = mock.mock.calls[0]![0];
+          expect(args.input).toEqual({
+            fullName: "John Doe",
+          });
+          expect(args.unsafeRawInput).toEqual({
+            name: "John",
+            lastName: "Doe",
           });
         });
 
         test(`should return Err if input is not valid for ${name} handler`, async () => {
-          const safeFn = createSafeFn();
+          const mock = vi.fn().mockResolvedValue(ok(""));
+          const safeFn = createMockFn(mock);
 
           // @ts-expect-error - Wrong input type
-          const res = await safeFn.run({});
+          const res = (await safeFn.run({})) as any;
           expect(res).toBeErr();
           assert(res.isErr());
           expect(res.error.code).toBe("INPUT_PARSING");
@@ -262,833 +262,867 @@ describe("runnable-safe-fn", () => {
           expect(res.error.cause.format().lastName).toBeDefined();
           expect(res.error.cause.format().name).toBeDefined();
         });
+
+        test("should pass parent input in array", async () => {
+          const mock = vi.fn().mockResolvedValue(ok(""));
+          const parent = createMockFn(mock);
+          const handlerMock = vi.fn().mockResolvedValue(ok(""));
+          const child = createSafeFn().use(parent).handler(handlerMock);
+
+          await child.run({ name: "John", lastName: "Doe" });
+
+          const args = handlerMock.mock.calls[0]![0];
+
+          console.log(JSON.stringify(args, null, 2));
+
+          expect(args.ctx.input).toEqual([
+            {
+              fullName: "John Doe",
+            },
+          ]);
+        });
       });
 
-      testCasesWithoutInputSchema.forEach(({ name, createSafeFn }) => {
+      testCasesWithoutInputSchema.forEach(({ name, createMockFn }) => {
         test(`should pass unparsed input to handler when input schema is not defined for ${name} handler`, async () => {
-          const safeFn = createSafeFn();
+          const mock = vi.fn().mockResolvedValue(ok(""));
+          const safeFn = createMockFn(mock);
           const res = await safeFn.run({ name: "John", lastName: "Doe" });
           expect(res).toBeOk();
-          assert(res.isOk());
-          expect(res.value).toEqual({
-            unsafeRawInput: { name: "John", lastName: "Doe" },
-          });
-        });
-
-        test("should pass undefined as parsed input if input is undefined", async () => {
-          const safeFn = createSafeFn();
-          const res = await safeFn.run(undefined as TODO);
-          expect(res).toBeOk();
-          assert(res.isOk());
-          expect(res.value).toEqual({
-            parsedInput: undefined,
-          });
-        });
-      });
-    });
-
-    describe("output", () => {
-      const outputSchema = z
-        .object({ name: z.string(), lastName: z.string() })
-        .transform((input) => ({
-          fullName: `${input.name} ${input.lastName}`,
-        }));
-
-      const testCasesWithOutputSchema = [
-        {
-          name: "regular",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<{ name: string; lastName: string }>()
-              .output(outputSchema)
-              .handler((args) => ok(args.unsafeRawInput)),
-        },
-        {
-          name: "async",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<{ name: string; lastName: string }>()
-              .output(outputSchema)
-              .handler(async (args) => ok(args.unsafeRawInput)),
-        },
-        {
-          name: "generator",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<{ name: string; lastName: string }>()
-              .output(outputSchema)
-              .safeHandler(async function* (args) {
-                return ok(args.unsafeRawInput);
-              }),
-        },
-      ];
-
-      const testCasesWithoutOutputSchema = [
-        {
-          name: "regular",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<{ name: string; lastName: string }>()
-              .handler((args) => ok(args.unsafeRawInput)),
-        },
-        {
-          name: "async",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<{ name: string; lastName: string }>()
-              .handler(async (args) => ok(args.unsafeRawInput)),
-        },
-        {
-          name: "generator",
-          createSafeFn: () =>
-            createSafeFn()
-              .unparsedInput<{ name: string; lastName: string }>()
-              .safeHandler(async function* (args) {
-                return ok(args.unsafeRawInput);
-              }),
-        },
-      ];
-
-      testCasesWithOutputSchema.forEach(({ name, createSafeFn }) => {
-        test(`should return Ok with parsed output for ${name} handler`, async () => {
-          const safeFn = createSafeFn();
-          const res = await safeFn.run({ name: "John", lastName: "Doe" });
-          expect(res).toBeOk();
-          assert(res.isOk());
-          expect(res.value).toEqual({
-            fullName: "John Doe",
-          });
-        });
-        test(`should return Err if output is not valid for ${name} handler`, async () => {
-          const safeFn = createSafeFn();
-          // @ts-expect-error
-          const res = await safeFn.run({});
-          expect(res).toBeErr();
-          assert(res.isErr());
-          expect(res.error.code).toBe("OUTPUT_PARSING");
-          assert(res.error.code === "OUTPUT_PARSING");
-          expect(res.error.cause).toBeInstanceOf(ZodError);
-          expect(res.error.cause.format().lastName).toBeDefined();
-          expect(res.error.cause.format().name).toBeDefined();
-        });
-      });
-
-      testCasesWithoutOutputSchema.forEach(({ name, createSafeFn }) => {
-        test(`should pass through output from handler if output schema is not defined for ${name} handler`, async () => {
-          const safeFn = createSafeFn();
-          const res = await safeFn.run({ name: "John", lastName: "Doe" });
-          expect(res).toBeOk();
-          assert(res.isOk());
-          expect(res.value).toEqual({
+          const args = mock.mock.calls[0]![0];
+          expect(args.unsafeRawInput).toEqual({
             name: "John",
             lastName: "Doe",
           });
         });
-      });
-    });
 
-    describe("uncaught error", () => {
-      const testCases = [
-        {
-          name: "regular",
-          createSafeFn: () =>
-            createSafeFn()
-              .handler(() => {
-                throw new Error("error");
-              })
-              .catch((e) =>
-                err({
-                  code: "TEST_ERROR",
-                  cause: e,
-                }),
-              ),
-        },
-        {
-          name: "async",
-          createSafeFn: () =>
-            createSafeFn()
-              .handler(async () => {
-                throw new Error("error");
-              })
-              .catch((e) =>
-                err({
-                  code: "TEST_ERROR",
-                  cause: e,
-                }),
-              ),
-        },
-        {
-          name: "generator",
-          createSafeFn: () =>
-            createSafeFn()
-              .safeHandler(async function* () {
-                throw new Error("error");
-              })
-              .catch((e) =>
-                err({
-                  code: "TEST_ERROR",
-                  cause: e,
-                }),
-              ),
-        },
-      ];
-
-      testCases.forEach(({ name, createSafeFn }) => {
-        test(`should run catch handler for ${name} handler`, async () => {
-          const safeFn = createSafeFn();
+        test("should pass undefined as parsed input if input is undefined", async () => {
+          const mock = vi.fn().mockResolvedValue(ok(""));
+          const safeFn = createMockFn(mock);
+          // @ts-expect-error - Wrong input type
           const res = await safeFn.run();
-          expect(res).toBeErr();
-          assert(res.isErr());
-          expect(res.error.code).toBe("TEST_ERROR");
-          assert(res.error.code === "TEST_ERROR");
-          expect(res.error.cause).toBeInstanceOf(Error);
-          assert(res.error.cause instanceof Error);
-          expect(res.error.cause.message).toBe("error");
+          expect(res).toBeOk();
+          const args = mock.mock.calls[0]![0];
+          expect(args.input).toEqual(undefined);
         });
       });
     });
+  });
 
-    describe("return error", async () => {
-      const outputParseMock = vi.fn();
-      const postYieldMock = vi.fn();
+  describe("output", () => {
+    const outputSchema = z
+      .object({ name: z.string(), lastName: z.string() })
+      .transform((input) => ({
+        fullName: `${input.name} ${input.lastName}`,
+      }));
 
-      const testCases = [
-        {
-          name: "regular",
-          createSafeFn: () => {
-            const builder = createSafeFn().handler(() => err("Ooh no!"));
-            builder._parseOutput = outputParseMock;
-            return builder;
-          },
-        },
-        {
-          name: "async",
-          createSafeFn: () => {
-            const builder = createSafeFn().handler(async () => err("Ooh no!"));
-            builder._parseOutput = outputParseMock;
-            return builder;
-          },
-        },
-        {
-          name: "generator - return error",
-          createSafeFn: () => {
-            const builder = createSafeFn().safeHandler(async function* () {
-              return err("Ooh no!");
-            });
-            builder._parseOutput = outputParseMock;
-            return builder;
-          },
-        },
-        {
-          name: "generator - yield error",
-          createSafeFn: () => {
-            const builder = createSafeFn().safeHandler(async function* () {
-              yield* err("Ooh no!").safeUnwrap();
-              postYieldMock();
-              return ok("Ooh yes!");
-            });
-            builder._parseOutput = outputParseMock;
-            return builder;
-          },
-        },
-      ] as const;
+    const testCasesWithOutputSchema = [
+      {
+        name: "regular",
+        createSafeFn: () =>
+          createSafeFn()
+            .unparsedInput<{ name: string; lastName: string }>()
+            .output(outputSchema)
+            .handler((args) => ok(args.unsafeRawInput)),
+      },
+      {
+        name: "async",
+        createSafeFn: () =>
+          createSafeFn()
+            .unparsedInput<{ name: string; lastName: string }>()
+            .output(outputSchema)
+            .handler(async (args) => ok(args.unsafeRawInput)),
+      },
+      {
+        name: "generator",
+        createSafeFn: () =>
+          createSafeFn()
+            .unparsedInput<{ name: string; lastName: string }>()
+            .output(outputSchema)
+            .safeHandler(async function* (args) {
+              return ok(args.unsafeRawInput);
+            }),
+      },
+    ];
 
-      testCases.forEach(({ name, createSafeFn }) => {
-        test(`should return error from ${name} handler`, async () => {
-          const safeFn = createSafeFn();
-          const res = await safeFn.run();
-          expect(res).toBeErr();
-          assert(res.isErr());
-          expect(res.error).toBe("Ooh no!");
-        });
-        test("should not run output parse if handler returned error", async () => {
-          const safeFn = createSafeFn();
-          const res = await safeFn.run();
-          expect(res).toBeErr();
-          assert(res.isErr());
-          expect(outputParseMock).not.toHaveBeenCalled();
+    const testCasesWithoutOutputSchema = [
+      {
+        name: "regular",
+        createSafeFn: () =>
+          createSafeFn()
+            .unparsedInput<{ name: string; lastName: string }>()
+            .handler((args) => ok(args.unsafeRawInput)),
+      },
+      {
+        name: "async",
+        createSafeFn: () =>
+          createSafeFn()
+            .unparsedInput<{ name: string; lastName: string }>()
+            .handler(async (args) => ok(args.unsafeRawInput)),
+      },
+      {
+        name: "generator",
+        createSafeFn: () =>
+          createSafeFn()
+            .unparsedInput<{ name: string; lastName: string }>()
+            .safeHandler(async function* (args) {
+              return ok(args.unsafeRawInput);
+            }),
+      },
+    ];
+
+    testCasesWithOutputSchema.forEach(({ name, createSafeFn }) => {
+      test(`should return Ok with parsed output for ${name} handler`, async () => {
+        const safeFn = createSafeFn();
+        const res = await safeFn.run({ name: "John", lastName: "Doe" });
+        expect(res).toBeOk();
+        assert(res.isOk());
+        expect(res.value).toEqual({
+          fullName: "John Doe",
         });
       });
+      test(`should return Err if output is not valid for ${name} handler`, async () => {
+        const safeFn = createSafeFn();
+        // @ts-expect-error
+        const res = await safeFn.run({});
+        expect(res).toBeErr();
+        assert(res.isErr());
+        expect(res.error.code).toBe("OUTPUT_PARSING");
+        assert(res.error.code === "OUTPUT_PARSING");
+        expect(res.error.cause).toBeInstanceOf(ZodError);
+        expect(res.error.cause.format().lastName).toBeDefined();
+        expect(res.error.cause.format().name).toBeDefined();
+      });
+    });
 
-      test("should escape early out of generator if it yields an error", async () => {
-        const safeFn = testCases[3].createSafeFn();
+    testCasesWithoutOutputSchema.forEach(({ name, createSafeFn }) => {
+      test(`should pass through output from handler if output schema is not defined for ${name} handler`, async () => {
+        const safeFn = createSafeFn();
+        const res = await safeFn.run({ name: "John", lastName: "Doe" });
+        expect(res).toBeOk();
+        assert(res.isOk());
+        expect(res.value).toEqual({
+          name: "John",
+          lastName: "Doe",
+        });
+      });
+    });
+  });
+
+  describe("uncaught error", () => {
+    const testCases = [
+      {
+        name: "regular",
+        createSafeFn: () =>
+          createSafeFn()
+            .handler(() => {
+              throw new Error("error");
+            })
+            .catch((e) =>
+              err({
+                code: "TEST_ERROR",
+                cause: e,
+              }),
+            ),
+      },
+      {
+        name: "async",
+        createSafeFn: () =>
+          createSafeFn()
+            .handler(async () => {
+              throw new Error("error");
+            })
+            .catch((e) =>
+              err({
+                code: "TEST_ERROR",
+                cause: e,
+              }),
+            ),
+      },
+      {
+        name: "generator",
+        createSafeFn: () =>
+          createSafeFn()
+            .safeHandler(async function* () {
+              throw new Error("error");
+            })
+            .catch((e) =>
+              err({
+                code: "TEST_ERROR",
+                cause: e,
+              }),
+            ),
+      },
+    ];
+
+    testCases.forEach(({ name, createSafeFn }) => {
+      test(`should run catch handler for ${name} handler`, async () => {
+        const safeFn = createSafeFn();
         const res = await safeFn.run();
         expect(res).toBeErr();
         assert(res.isErr());
-        expect(postYieldMock).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("callbacks", () => {
-      describe("should run callbacks with right args in success case", async () => {
-        const callbackMocks = {
-          onStart: vi.fn(),
-          onSuccess: vi.fn(),
-          onError: vi.fn(),
-          onComplete: vi.fn(),
-        };
-
-        const parentInputSchema = z.object({ age: z.number() });
-        const parent = createSafeFn()
-          .input(parentInputSchema)
-          .handler(() => ok("Parent!" as const));
-
-        const childInputSchema = z.object({ name: z.string() });
-        const safeFn = createSafeFn()
-          .use(parent)
-          .input(childInputSchema)
-          .handler(() => ok("Ok!" as const))
-          .onStart(callbackMocks.onStart)
-          .onSuccess(callbackMocks.onSuccess)
-          .onError(callbackMocks.onError)
-          .onComplete(callbackMocks.onComplete);
-
-        await safeFn.run({ name: "John", age: 100 });
-
-        type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
-        type CallbackArgs = {
-          [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
-            args: infer Args,
-          ) => void
-            ? Args
-            : never;
-        };
-
-        test("onError", () => {
-          expect(callbackMocks.onError).not.toHaveBeenCalled();
-        });
-
-        test("onStart", () => {
-          expect(callbackMocks.onStart).toHaveBeenCalledWith({
-            unsafeRawInput: { name: "John", age: 100 },
-          } satisfies CallbackArgs["onStart"]);
-        });
-
-        test("onSuccess", () => {
-          expect(callbackMocks.onSuccess).toHaveBeenCalledWith({
-            input: { name: "John", age: 100 },
-            unsafeRawInput: { name: "John", age: 100 },
-            ctx: "Parent!",
-            value: "Ok!",
-          } satisfies CallbackArgs["onSuccess"]);
-        });
-
-        test("onComplete", () => {
-          expect(callbackMocks.onComplete).toHaveBeenCalledWith({
-            asAction: false,
-            input: { name: "John", age: 100 },
-            unsafeRawInput: { name: "John", age: 100 },
-            ctx: "Parent!",
-            result: ok("Ok!"),
-          } satisfies CallbackArgs["onComplete"]);
-        });
-      });
-
-      describe("should run callbacks with right args when child returns Err", async () => {
-        const callbackMocks = {
-          onStart: vi.fn(),
-          onSuccess: vi.fn(),
-          onError: vi.fn(),
-          onComplete: vi.fn(),
-        };
-
-        const parentInputSchema = z.object({ age: z.number() });
-        const childInputSchema = z.object({ name: z.string() });
-
-        const parent = createSafeFn()
-          .input(parentInputSchema)
-          .handler(() => ok("Parent!" as const));
-
-        const safeFn = createSafeFn()
-          .use(parent)
-          .input(childInputSchema)
-          .handler((args) => {
-            return err("Woops!");
-          })
-          .onStart(callbackMocks.onStart)
-          .onSuccess(callbackMocks.onSuccess)
-          .onError(callbackMocks.onError)
-          .onComplete(callbackMocks.onComplete);
-
-        type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
-        type CallbackArgs = {
-          [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
-            args: infer Args,
-          ) => void
-            ? Args
-            : never;
-        };
-
-        await safeFn.run({ name: "John", age: 100 });
-
-        test("onStart", () => {
-          expect(callbackMocks.onStart).toHaveBeenCalledWith({
-            unsafeRawInput: { name: "John", age: 100 },
-          } satisfies CallbackArgs["onStart"]);
-        });
-
-        test("onSuccess", () => {
-          expect(callbackMocks.onSuccess).not.toHaveBeenCalled();
-        });
-
-        test("onError", () => {
-          expect(callbackMocks.onError).toHaveBeenCalledWith({
-            asAction: false,
-            error: "Woops!",
-            ctx: "Parent!",
-            input: { name: "John", age: 100 },
-            unsafeRawInput: { name: "John", age: 100 },
-          } satisfies CallbackArgs["onError"]);
-        });
-
-        test("onComplete", () => {
-          expect(callbackMocks.onComplete).toHaveBeenCalledWith({
-            asAction: false,
-            input: { name: "John", age: 100 },
-            unsafeRawInput: { name: "John", age: 100 },
-            ctx: "Parent!",
-            result: err("Woops!"),
-          } satisfies CallbackArgs["onComplete"]);
-        });
-      });
-
-      describe("should run callbacks with right args when parent returns Err", async () => {
-        const callbackMocks = {
-          onStart: vi.fn(),
-          onSuccess: vi.fn(),
-          onError: vi.fn(),
-          onComplete: vi.fn(),
-        };
-
-        const parentInputSchema = z.object({ age: z.number() });
-        const childInputSchema = z.object({ name: z.string() });
-
-        const parent = createSafeFn()
-          .input(parentInputSchema)
-          .handler(() => err("Parent!" as const));
-
-        const safeFn = createSafeFn()
-          .use(parent)
-          .input(childInputSchema)
-          .handler((args) => {
-            return ok("Child");
-          })
-          .onStart(callbackMocks.onStart)
-          .onSuccess(callbackMocks.onSuccess)
-          .onError(callbackMocks.onError)
-          .onComplete(callbackMocks.onComplete);
-
-        type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
-        type CallbackArgs = {
-          [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
-            args: infer Args,
-          ) => void
-            ? Args
-            : never;
-        };
-
-        await safeFn.run({ name: "John", age: 100 });
-
-        test("onStart", () => {
-          expect(callbackMocks.onStart).toHaveBeenCalledWith({
-            unsafeRawInput: { name: "John", age: 100 },
-          } satisfies CallbackArgs["onStart"]);
-        });
-
-        test("onSuccess", () => {
-          expect(callbackMocks.onSuccess).not.toHaveBeenCalled();
-        });
-
-        test("onError", () => {
-          expect(callbackMocks.onError).toHaveBeenCalledWith({
-            asAction: false,
-            error: "Parent!",
-            ctx: undefined,
-            input: undefined,
-            unsafeRawInput: { name: "John", age: 100 },
-          } satisfies CallbackArgs["onError"]);
-        });
-
-        test("onComplete", () => {
-          expect(callbackMocks.onComplete).toHaveBeenCalledWith({
-            asAction: false,
-            input: undefined,
-            unsafeRawInput: { name: "John", age: 100 },
-            ctx: undefined,
-            result: err("Parent!"),
-          } satisfies CallbackArgs["onComplete"]);
-        });
-      });
-
-      describe("should run callbacks with right args when parent fails parsing", async () => {
-        const callbackMocks = {
-          onStart: vi.fn(),
-          onSuccess: vi.fn(),
-          onError: vi.fn(),
-          onComplete: vi.fn(),
-        };
-
-        const parentInputSchema = z.object({ age: z.number() });
-        const childInputSchema = z.object({ name: z.string() });
-
-        const parent = createSafeFn()
-          .input(parentInputSchema)
-          .handler(() => ok("Parent!" as const));
-
-        const safeFn = createSafeFn()
-          .use(parent)
-          .input(childInputSchema)
-          .handler((args) => {
-            return ok("Child");
-          })
-          .onStart(callbackMocks.onStart)
-          .onSuccess(callbackMocks.onSuccess)
-          .onError(callbackMocks.onError)
-          .onComplete(callbackMocks.onComplete);
-
-        type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
-        type CallbackArgs = {
-          [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
-            args: infer Args,
-          ) => void
-            ? Args
-            : never;
-        };
-
-        // @ts-expect-error - passing wrong inputs on purpose
-        await safeFn.run({ fake: "fake", data: "data" });
-
-        test("onStart", () => {
-          expect(callbackMocks.onStart).toHaveBeenCalledWith({
-            unsafeRawInput: { fake: "fake", data: "data" },
-          });
-        });
-
-        test("onSuccess", () => {
-          expect(callbackMocks.onSuccess).not.toHaveBeenCalled();
-        });
-
-        test("onError", () => {
-          expect(callbackMocks.onError).toHaveBeenCalled();
-
-          const args = callbackMocks.onError.mock
-            .calls[0]![0] as CallbackArgs["onError"];
-
-          assert(args.asAction === false);
-          assert(args.ctx === undefined);
-          assert(args.input === undefined);
-          assert(args.error.code === "INPUT_PARSING");
-          assert(args.error.cause instanceof ZodError);
-          expect(args.error.cause.format()).toHaveProperty(["age"]);
-        });
-
-        test("onComplete", () => {
-          expect(callbackMocks.onComplete).toHaveBeenCalled();
-          const args = callbackMocks.onComplete.mock
-            .calls[0]![0] as CallbackArgs["onComplete"];
-
-          assert(args.asAction === false);
-          assert(args.ctx === undefined);
-          assert(args.input === undefined);
-          assert(args.result.isErr());
-          assert(args.result.error.code === "INPUT_PARSING");
-          assert(args.result.error.cause instanceof ZodError);
-          expect(args.result.error.cause.format()).toHaveProperty(["age"]);
-        });
+        expect(res.error.code).toBe("TEST_ERROR");
+        assert(res.error.code === "TEST_ERROR");
+        expect(res.error.cause).toBeInstanceOf(Error);
+        assert(res.error.cause instanceof Error);
+        expect(res.error.cause.message).toBe("error");
       });
     });
   });
 
-  describe("parent", () => {
-    const parents = [
+  describe("return error", async () => {
+    const outputParseMock = vi.fn().mockResolvedValue(ok(""));
+    const postYieldMock = vi.fn().mockResolvedValue(ok(""));
+
+    const testCases = [
       {
         name: "regular",
-        createSafeFn: () => createSafeFn().handler((args) => ok("Ok!")),
+        createSafeFn: () => {
+          const builder = createSafeFn().handler(() => err("Ooh no!"));
+          builder._parseOutput = outputParseMock;
+          return builder;
+        },
       },
       {
         name: "async",
-        createSafeFn: () => createSafeFn().handler(async (args) => ok("Ok!")),
-      },
-      {
-        name: "generator",
-        createSafeFn: () =>
-          createSafeFn().safeHandler(async function* (args) {
-            return ok("Ok!");
-          }),
-      },
-    ];
-
-    const children = [
-      {
-        name: "regular",
-        createSafeFn: (parent: AnyRunnableSafeFn) =>
-          createSafeFn()
-            .use(parent)
-            .handler((args) => ok(args.ctx)),
-      },
-      {
-        name: "async",
-        createSafeFn: (parent: AnyRunnableSafeFn) =>
-          createSafeFn()
-            .use(parent)
-            .handler(async (args) => ok(args.ctx)),
-      },
-      {
-        name: "generator",
-        createSafeFn: (parent: AnyRunnableSafeFn) =>
-          createSafeFn()
-            .use(parent)
-            .safeHandler(async function* (args) {
-              return ok(args.ctx);
-            }),
-      },
-    ];
-
-    parents.forEach(
-      ({ name: parentName, createSafeFn: createParentSafeFn }) => {
-        children.forEach(
-          ({ name: childName, createSafeFn: createChildSafeFn }) => {
-            test(`should pass parent result from ${parentName} to ${childName}`, async () => {
-              const parent = createParentSafeFn();
-              const child = createChildSafeFn(parent as AnyRunnableSafeFn);
-              // @ts-expect-error - cast to any so input is not compatible
-              const res = await child.run();
-              expect(res).toBeOk();
-              assert(res.isOk());
-              expect(res.value).toBe("Ok!");
-            });
-          },
-        );
-      },
-    );
-
-    const parentsWithError = [
-      {
-        name: "regular",
-        createSafeFn: () => createSafeFn().handler((args) => err("Not ok!")),
-      },
-      {
-        name: "async",
-        createSafeFn: () =>
-          createSafeFn().handler(async (args) => err("Not ok!")),
+        createSafeFn: () => {
+          const builder = createSafeFn().handler(async () => err("Ooh no!"));
+          builder._parseOutput = outputParseMock;
+          return builder;
+        },
       },
       {
         name: "generator - return error",
-        createSafeFn: () =>
-          createSafeFn().safeHandler(async function* (args) {
-            return err("Not ok!");
-          }),
+        createSafeFn: () => {
+          const builder = createSafeFn().safeHandler(async function* () {
+            return err("Ooh no!");
+          });
+          builder._parseOutput = outputParseMock;
+          return builder;
+        },
       },
       {
         name: "generator - yield error",
-        createSafeFn: () =>
-          createSafeFn().safeHandler(async function* (args) {
-            yield* err("Not ok!").safeUnwrap();
-            return ok("Ok!");
-          }),
+        createSafeFn: () => {
+          const builder = createSafeFn().safeHandler(async function* () {
+            yield* err("Ooh no!").safeUnwrap();
+            postYieldMock();
+            return ok("Ooh yes!");
+          });
+          builder._parseOutput = outputParseMock;
+          return builder;
+        },
       },
-    ];
+    ] as const;
 
-    const childrenWithMocks = [
-      {
-        name: "regular",
-        createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          createSafeFn().use(parent).handler(mockHandler),
-      },
-      {
-        name: "async",
-        createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          createSafeFn()
-            .use(parent)
-            .handler(async () => mockHandler()),
-      },
-      {
-        name: "generator",
-        createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
-          createSafeFn()
-            .use(parent)
-            .safeHandler(async function* () {
-              return mockHandler();
-            }),
-      },
-    ];
-    parentsWithError.forEach(
-      ({ name: parentName, createSafeFn: createParentSafeFn }) => {
-        childrenWithMocks.forEach(
-          async ({ name: childName, createSafeFn: createChildSafeFn }) => {
-            const mockHandler = vi.fn();
-            const parent = createParentSafeFn();
-            const child = createChildSafeFn(
-              parent as AnyRunnableSafeFn,
-              mockHandler,
-            );
+    testCases.forEach(({ name, createSafeFn }) => {
+      test(`should return error from ${name} handler`, async () => {
+        const safeFn = createSafeFn();
+        const res = await safeFn.run();
+        expect(res).toBeErr();
+        assert(res.isErr());
+        expect(res.error).toBe("Ooh no!");
+      });
+      test("should not run output parse if handler returned error", async () => {
+        const safeFn = createSafeFn();
+        const res = await safeFn.run();
+        expect(res).toBeErr();
+        assert(res.isErr());
+        expect(outputParseMock).not.toHaveBeenCalled();
+      });
+    });
 
-            // @ts-expect-error - cast to any so input is not compatible
-            const res = await child.run();
-            test(`should pass error from ${parentName} to ${childName}`, () => {
-              expect(res).toBeErr();
-              assert(res.isErr());
-              expect(res.error).toBe("Not ok!");
-            });
-            test(`should not call ${childName} handler for error in ${parentName}`, () => {
-              expect(mockHandler).not.toHaveBeenCalled();
-            });
-          },
-        );
-      },
-    );
+    test("should escape early out of generator if it yields an error", async () => {
+      const safeFn = testCases[3].createSafeFn();
+      const res = await safeFn.run();
+      expect(res).toBeErr();
+      assert(res.isErr());
+      expect(postYieldMock).not.toHaveBeenCalled();
+    });
+  });
 
-    test("should pass parsed and unparsed input from parent to child", async () => {
-      // TODO: also do for other types of handlers
-      const fn1 = createSafeFn()
-        .input(
-          z.object({
-            parsed1: z.string(),
-          }),
-        )
-        .handler(() => ok(""));
+  describe("callbacks", () => {
+    describe("should run callbacks with right args in success case", async () => {
+      const callbackMocks = {
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+        onComplete: vi.fn(),
+      };
 
-      const fn2 = createSafeFn()
-        .use(fn1)
-        .unparsedInput<{ unparsed2: string }>()
-        .handler(() => ok("ctx"));
-      const fn3 = createSafeFn()
-        .use(fn2)
-        .input(
-          z.object({
-            parsed3: z.string(),
-          }),
-        )
-        .handler((args) => ok(args));
+      const parentInputSchema = z.object({ age: z.number() });
+      const parent = createSafeFn()
+        .input(parentInputSchema)
+        .handler(() => ok("Parent!" as const));
 
-      const res = await fn3.run({
-        parsed1: "parsed1",
-        unparsed2: "unparsed2",
-        parsed3: "parsed3",
+      const childInputSchema = z.object({ name: z.string() });
+      const safeFn = createSafeFn()
+        .use(parent)
+        .input(childInputSchema)
+        .handler(() => ok("Ok!" as const))
+        .onStart(callbackMocks.onStart)
+        .onSuccess(callbackMocks.onSuccess)
+        .onError(callbackMocks.onError)
+        .onComplete(callbackMocks.onComplete);
+
+      await safeFn.run({ name: "John", age: 100 });
+
+      type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
+      type CallbackArgs = {
+        [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
+          args: infer Args,
+        ) => void
+          ? Args
+          : never;
+      };
+
+      test("onError", () => {
+        expect(callbackMocks.onError).not.toHaveBeenCalled();
       });
 
-      expect(res).toBeOk();
-      assert(res.isOk());
-      expect(res.value).toEqual({
-        ctx: "ctx",
-        input: {
-          parsed1: "parsed1",
-          parsed3: "parsed3",
-        },
-        unsafeRawInput: {
-          parsed1: "parsed1",
-          unparsed2: "unparsed2",
-          parsed3: "parsed3",
-        },
+      test("onStart", () => {
+        expect(callbackMocks.onStart).toHaveBeenCalledWith({
+          unsafeRawInput: { name: "John", age: 100 },
+        } satisfies CallbackArgs["onStart"]);
+      });
+
+      test("onSuccess", () => {
+        expect(callbackMocks.onSuccess).toHaveBeenCalledWith({
+          input: { name: "John" },
+          unsafeRawInput: { name: "John", age: 100 },
+          ctx: {
+            value: "Parent!",
+            input: [{ age: 100 }],
+          },
+          value: "Ok!",
+        } satisfies CallbackArgs["onSuccess"]);
+      });
+
+      test("onComplete", () => {
+        expect(callbackMocks.onComplete).toHaveBeenCalledWith({
+          asAction: false,
+          input: { name: "John" },
+          unsafeRawInput: { name: "John", age: 100 },
+          ctx: {
+            value: "Parent!",
+            input: [{ age: 100 }],
+          },
+          result: ok("Ok!"),
+        } satisfies CallbackArgs["onComplete"]);
+      });
+    });
+
+    describe("should run callbacks with right args when child returns Err", async () => {
+      const callbackMocks = {
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+        onComplete: vi.fn(),
+      };
+
+      const parentInputSchema = z.object({ age: z.number() });
+      const childInputSchema = z.object({ name: z.string() });
+
+      const parent = createSafeFn()
+        .input(parentInputSchema)
+        .handler(() => ok("Parent!" as const));
+
+      const safeFn = createSafeFn()
+        .use(parent)
+        .input(childInputSchema)
+        .handler((args) => {
+          return err("Woops!");
+        })
+        .onStart(callbackMocks.onStart)
+        .onSuccess(callbackMocks.onSuccess)
+        .onError(callbackMocks.onError)
+        .onComplete(callbackMocks.onComplete);
+
+      type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
+      type CallbackArgs = {
+        [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
+          args: infer Args,
+        ) => void
+          ? Args
+          : never;
+      };
+
+      await safeFn.run({ name: "John", age: 100 });
+
+      test("onStart", () => {
+        expect(callbackMocks.onStart).toHaveBeenCalledWith({
+          unsafeRawInput: { name: "John", age: 100 },
+        } satisfies CallbackArgs["onStart"]);
+      });
+
+      test("onSuccess", () => {
+        expect(callbackMocks.onSuccess).not.toHaveBeenCalled();
+      });
+
+      test("onError", () => {
+        expect(callbackMocks.onError).toHaveBeenCalledWith({
+          asAction: false,
+          error: "Woops!",
+          ctx: {
+            value: "Parent!",
+            input: [{ age: 100 }],
+          },
+          input: { name: "John" },
+          unsafeRawInput: { name: "John", age: 100 },
+        } satisfies CallbackArgs["onError"]);
+      });
+
+      test("onComplete", () => {
+        expect(callbackMocks.onComplete).toHaveBeenCalledWith({
+          asAction: false,
+          input: { name: "John" },
+          unsafeRawInput: { name: "John", age: 100 },
+          ctx: {
+            value: "Parent!",
+            input: [{ age: 100 }],
+          },
+          result: err("Woops!"),
+        } satisfies CallbackArgs["onComplete"]);
+      });
+    });
+
+    describe("should run callbacks with right args when parent returns Err", async () => {
+      const callbackMocks = {
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+        onComplete: vi.fn(),
+      };
+
+      const parentInputSchema = z.object({ age: z.number() });
+      const childInputSchema = z.object({ name: z.string() });
+
+      const parent = createSafeFn()
+        .input(parentInputSchema)
+        .handler(() => err("Parent!" as const));
+
+      const safeFn = createSafeFn()
+        .use(parent)
+        .input(childInputSchema)
+        .handler((args) => {
+          return ok("Child");
+        })
+        .onStart(callbackMocks.onStart)
+        .onSuccess(callbackMocks.onSuccess)
+        .onError(callbackMocks.onError)
+        .onComplete(callbackMocks.onComplete);
+
+      type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
+      type CallbackArgs = {
+        [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
+          args: infer Args,
+        ) => void
+          ? Args
+          : never;
+      };
+
+      await safeFn.run({ name: "John", age: 100 });
+
+      test("onStart", () => {
+        expect(callbackMocks.onStart).toHaveBeenCalledWith({
+          unsafeRawInput: { name: "John", age: 100 },
+        } satisfies CallbackArgs["onStart"]);
+      });
+
+      test("onSuccess", () => {
+        expect(callbackMocks.onSuccess).not.toHaveBeenCalled();
+      });
+
+      test("onError", () => {
+        expect(callbackMocks.onError).toHaveBeenCalledWith({
+          asAction: false,
+          error: "Parent!",
+          ctx: undefined,
+          input: undefined,
+          unsafeRawInput: { name: "John", age: 100 },
+        } satisfies CallbackArgs["onError"]);
+      });
+
+      test("onComplete", () => {
+        expect(callbackMocks.onComplete).toHaveBeenCalledWith({
+          asAction: false,
+          input: undefined,
+          unsafeRawInput: { name: "John", age: 100 },
+          ctx: undefined,
+          result: err("Parent!"),
+        } satisfies CallbackArgs["onComplete"]);
+      });
+    });
+
+    describe("should run callbacks with right args when parent fails parsing", async () => {
+      const callbackMocks = {
+        onStart: vi.fn(),
+        onSuccess: vi.fn(),
+        onError: vi.fn(),
+        onComplete: vi.fn(),
+      };
+
+      const parentInputSchema = z.object({ age: z.number() });
+      const childInputSchema = z.object({ name: z.string() });
+
+      const parent = createSafeFn()
+        .input(parentInputSchema)
+        .handler(() => ok("Parent!" as const));
+
+      const safeFn = createSafeFn()
+        .use(parent)
+        .input(childInputSchema)
+        .handler((args) => {
+          return ok("Child");
+        })
+        .onStart(callbackMocks.onStart)
+        .onSuccess(callbackMocks.onSuccess)
+        .onError(callbackMocks.onError)
+        .onComplete(callbackMocks.onComplete);
+
+      type Callbacks = TInferSafeFnCallbacks<typeof safeFn>;
+      type CallbackArgs = {
+        [K in keyof Callbacks]: Exclude<Callbacks[K], undefined> extends (
+          args: infer Args,
+        ) => void
+          ? Args
+          : never;
+      };
+
+      // @ts-expect-error - passing wrong inputs on purpose
+      await safeFn.run({ fake: "fake", data: "data" });
+
+      test("onStart", () => {
+        expect(callbackMocks.onStart).toHaveBeenCalledWith({
+          unsafeRawInput: { fake: "fake", data: "data" },
+        });
+      });
+
+      test("onSuccess", () => {
+        expect(callbackMocks.onSuccess).not.toHaveBeenCalled();
+      });
+
+      test("onError", () => {
+        expect(callbackMocks.onError).toHaveBeenCalled();
+
+        const args = callbackMocks.onError.mock
+          .calls[0]![0] as CallbackArgs["onError"];
+
+        assert(args.asAction === false);
+        assert(args.ctx === undefined);
+        assert(args.input === undefined);
+        assert(args.error.code === "INPUT_PARSING");
+        assert(args.error.cause instanceof ZodError);
+        expect(args.error.cause.format()).toHaveProperty(["age"]);
+      });
+
+      test("onComplete", () => {
+        expect(callbackMocks.onComplete).toHaveBeenCalled();
+        const args = callbackMocks.onComplete.mock
+          .calls[0]![0] as CallbackArgs["onComplete"];
+
+        assert(args.asAction === false);
+        assert(args.ctx === undefined);
+        assert(args.input === undefined);
+        assert(args.result.isErr());
+        assert(args.result.error.code === "INPUT_PARSING");
+        assert(args.result.error.cause instanceof ZodError);
+        expect(args.result.error.cause.format()).toHaveProperty(["age"]);
+      });
+    });
+  });
+});
+
+describe("parent", () => {
+  const parents = [
+    {
+      name: "regular",
+      createSafeFn: () => createSafeFn().handler((args) => ok("Parent!")),
+    },
+    {
+      name: "async",
+      createSafeFn: () => createSafeFn().handler(async (args) => ok("Parent!")),
+    },
+    {
+      name: "generator",
+      createSafeFn: () =>
+        createSafeFn().safeHandler(async function* (args) {
+          return ok("Parent!");
+        }),
+    },
+  ];
+
+  const children = [
+    {
+      name: "regular",
+      createSafeFn: (parent: AnyRunnableSafeFn, handlerMock: Mock) =>
+        createSafeFn().use(parent).handler(handlerMock),
+    },
+    {
+      name: "async",
+      createSafeFn: (parent: AnyRunnableSafeFn, handlerMock: Mock) =>
+        createSafeFn().use(parent).handler(handlerMock),
+    },
+    {
+      name: "generator",
+      createSafeFn: (parent: AnyRunnableSafeFn, handlerMock: Mock) =>
+        createSafeFn()
+          .use(parent)
+          .safeHandler(async function* (args) {
+            return handlerMock(args);
+          }),
+    },
+  ];
+
+  parents.forEach(({ name: parentName, createSafeFn: createParentSafeFn }) => {
+    children.forEach(({ name: childName, createSafeFn: createChildSafeFn }) => {
+      test(`should pass parent ctx from ${parentName} to ${childName}`, async () => {
+        const parent = createParentSafeFn();
+        const handlerMock = vi.fn().mockResolvedValue(ok(""));
+        const child = createChildSafeFn(
+          parent as AnyRunnableSafeFn,
+          handlerMock,
+        );
+        // @ts-expect-error - cast to any so input is not compatible
+        const res = await child.run();
+
+        const args = handlerMock.mock.calls[0]![0];
+        expect(args.ctx).toEqual({
+          value: "Parent!",
+          input: [undefined],
+        });
       });
     });
   });
 
-  describe("createAction", () => {
-    describe("input", async () => {
-      test("should transform input error", async () => {
-        const action = createSafeFn()
-          .input(z.object({ name: z.string() }))
-          .handler((args) => ok(args))
-          .createAction();
+  const parentsWithError = [
+    {
+      name: "regular",
+      createSafeFn: () => createSafeFn().handler((args) => err("Not ok!")),
+    },
+    {
+      name: "async",
+      createSafeFn: () =>
+        createSafeFn().handler(async (args) => err("Not ok!")),
+    },
+    {
+      name: "generator - return error",
+      createSafeFn: () =>
+        createSafeFn().safeHandler(async function* (args) {
+          return err("Not ok!");
+        }),
+    },
+    {
+      name: "generator - yield error",
+      createSafeFn: () =>
+        createSafeFn().safeHandler(async function* (args) {
+          yield* err("Not ok!").safeUnwrap();
+          return ok("Ok!");
+        }),
+    },
+  ];
 
-        // @ts-expect-error
-        const res = await action({});
-        expect(res.ok).toBe(false);
-        assert(!res.ok);
-        expect(res.error.code).toBe("INPUT_PARSING");
-        assert(res.error.code === "INPUT_PARSING");
-        expect(res.error.cause).toHaveProperty(["formattedError"]);
-        expect(res.error.cause.formattedError).toHaveProperty(["name"]);
-        expect(res.error.cause).toHaveProperty(["flattenedError"]);
-      });
-
-      test("should transform input error from parent", async () => {
-        const parent = createSafeFn()
-          .input(z.object({ name: z.string() }))
-          .handler((args) => ok(args));
-        const child = createSafeFn()
+  const childrenWithMocks = [
+    {
+      name: "regular",
+      createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
+        createSafeFn().use(parent).handler(mockHandler),
+    },
+    {
+      name: "async",
+      createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
+        createSafeFn()
           .use(parent)
-          .input(z.object({ age: z.number() }))
-          .handler((args) => ok(args))
-          .createAction();
+          .handler(async () => mockHandler()),
+    },
+    {
+      name: "generator",
+      createSafeFn: (parent: AnyRunnableSafeFn, mockHandler: Mock) =>
+        createSafeFn()
+          .use(parent)
+          .safeHandler(async function* () {
+            return mockHandler();
+          }),
+    },
+  ];
+  parentsWithError.forEach(
+    ({ name: parentName, createSafeFn: createParentSafeFn }) => {
+      childrenWithMocks.forEach(
+        async ({ name: childName, createSafeFn: createChildSafeFn }) => {
+          const mockHandler = vi.fn().mockResolvedValue(ok(""));
+          const parent = createParentSafeFn();
+          const child = createChildSafeFn(
+            parent as AnyRunnableSafeFn,
+            mockHandler,
+          );
 
-        // @ts-expect-error
-        const res = await child({});
-        expect(res.ok).toBe(false);
-        assert(!res.ok);
-        expect(res.error.code).toBe("INPUT_PARSING");
-        assert(res.error.code === "INPUT_PARSING");
-        expect(res.error.cause).toHaveProperty(["formattedError"]);
-        expect(res.error.cause.formattedError).toHaveProperty(["name"]);
-        expect(res.error.cause).toHaveProperty(["flattenedError"]);
-      });
+          // @ts-expect-error - cast to any so input is not compatible
+          const res = await child.run();
+          test(`should pass error from ${parentName} to ${childName}`, () => {
+            expect(res).toBeErr();
+            assert(res.isErr());
+            expect(res.error).toBe("Not ok!");
+          });
+          test(`should not call ${childName} handler for error in ${parentName}`, () => {
+            expect(mockHandler).not.toHaveBeenCalled();
+          });
+        },
+      );
+    },
+  );
+
+  test("should pass parsed and unparsed input from parent to child", async () => {
+    // TODO: also do for other types of handlers
+    const fn1 = createSafeFn()
+      .input(
+        z.object({
+          parsed1: z.string(),
+        }),
+      )
+      .handler(() => ok(""));
+
+    const fn2 = createSafeFn()
+      .use(fn1)
+      .unparsedInput<{ unparsed2: string }>()
+      .handler(() => ok("ctx"));
+    const fn3 = createSafeFn()
+      .use(fn2)
+      .input(
+        z.object({
+          parsed3: z.string(),
+        }),
+      )
+      .handler((args) => ok(args));
+
+    const res = await fn3.run({
+      parsed1: "parsed1",
+      unparsed2: "unparsed2",
+      parsed3: "parsed3",
     });
 
-    describe("output", () => {
-      test("should transform output error", async () => {
-        const action = createSafeFn()
-          .output(z.object({ name: z.string() }))
-          // @ts-expect-error - passing wrong input on purpose
-          .handler((args) => {
-            return ok({});
-          })
-          .createAction();
+    expect(res).toBeOk();
+    assert(res.isOk());
+    expect(res.value).toEqual({
+      ctx: {
+        value: "ctx",
+        input: [{ parsed1: "parsed1" }, undefined],
+      },
+      input: {
+        parsed3: "parsed3",
+      },
+      unsafeRawInput: {
+        parsed1: "parsed1",
+        unparsed2: "unparsed2",
+        parsed3: "parsed3",
+      },
+    });
+  });
+});
 
-        const res = await action();
-        expect(res.ok).toBe(false);
-        assert(!res.ok);
-        expect(res.error.code).toBe("OUTPUT_PARSING");
-        assert(res.error.code === "OUTPUT_PARSING");
-        expect(res.error.cause).toHaveProperty(["formattedError"]);
-        expect(res.error.cause.formattedError).toHaveProperty(["name"]);
-        expect(res.error.cause).toHaveProperty(["flattenedError"]);
-      });
+describe("createAction", () => {
+  describe("input", async () => {
+    test("should transform input error", async () => {
+      const action = createSafeFn()
+        .input(z.object({ name: z.string() }))
+        .handler((args) => ok(args))
+        .createAction();
 
-      test("should transform output error from parent", async () => {
-        const parent = createSafeFn()
-          .output(z.object({ name: z.string() }))
-          //@ts-expect-error - passing wrong input on purpose
-          .handler((args) => {
-            return ok({});
-          });
-        const child = createSafeFn()
-          .use(parent)
-          .handler((args) => ok(args))
-          .createAction();
+      // @ts-expect-error
+      const res = await action({});
+      expect(res.ok).toBe(false);
+      assert(!res.ok);
+      expect(res.error.code).toBe("INPUT_PARSING");
+      assert(res.error.code === "INPUT_PARSING");
+      expect(res.error.cause).toHaveProperty(["formattedError"]);
+      expect(res.error.cause.formattedError).toHaveProperty(["name"]);
+      expect(res.error.cause).toHaveProperty(["flattenedError"]);
+    });
 
-        const res = await child();
+    test("should transform input error from parent", async () => {
+      const parent = createSafeFn()
+        .input(z.object({ name: z.string() }))
+        .handler((args) => ok(args));
+      const child = createSafeFn()
+        .use(parent)
+        .input(z.object({ age: z.number() }))
+        .handler((args) => ok(args))
+        .createAction();
 
-        expect(res.ok).toBe(false);
-        assert(!res.ok);
+      // @ts-expect-error
+      const res = await child({});
+      expect(res.ok).toBe(false);
+      assert(!res.ok);
+      expect(res.error.code).toBe("INPUT_PARSING");
+      assert(res.error.code === "INPUT_PARSING");
+      expect(res.error.cause).toHaveProperty(["formattedError"]);
+      expect(res.error.cause.formattedError).toHaveProperty(["name"]);
+      expect(res.error.cause).toHaveProperty(["flattenedError"]);
+    });
+  });
 
-        expect(res.error.code).toBe("OUTPUT_PARSING");
-        assert(res.error.code === "OUTPUT_PARSING");
-        expect(res.error.cause).toHaveProperty(["formattedError"]);
-        expect(res.error.cause.formattedError).toHaveProperty(["name"]);
-        expect(res.error.cause).toHaveProperty(["flattenedError"]);
+  describe("output", () => {
+    test("should transform output error", async () => {
+      const action = createSafeFn()
+        .output(z.object({ name: z.string() }))
+        // @ts-expect-error - passing wrong input on purpose
+        .handler((args) => {
+          return ok({});
+        })
+        .createAction();
 
-        const child2 = createSafeFn()
-          .use(parent)
-          .output(z.object({ age: z.number() }))
-          .handler(() => {
-            return ok({ age: 100 });
-          });
+      const res = await action();
+      expect(res.ok).toBe(false);
+      assert(!res.ok);
+      expect(res.error.code).toBe("OUTPUT_PARSING");
+      assert(res.error.code === "OUTPUT_PARSING");
+      expect(res.error.cause).toHaveProperty(["formattedError"]);
+      expect(res.error.cause.formattedError).toHaveProperty(["name"]);
+      expect(res.error.cause).toHaveProperty(["flattenedError"]);
+    });
 
-        const child3 = createSafeFn()
-          .use(child2)
-          .handler(() => ok({}))
-          .createAction();
+    test("should transform output error from parent", async () => {
+      const parent = createSafeFn()
+        .output(z.object({ name: z.string() }))
+        //@ts-expect-error - passing wrong input on purpose
+        .handler((args) => {
+          return ok({});
+        });
+      const child = createSafeFn()
+        .use(parent)
+        .handler((args) => ok(args))
+        .createAction();
 
-        const res2 = await child3();
-        expect(res2.ok).toBe(false);
-        assert(!res2.ok);
-        expect(res2.error.code).toBe("OUTPUT_PARSING");
-        assert(res2.error.code === "OUTPUT_PARSING");
-        expect(res2.error.cause).toHaveProperty(["formattedError"]);
-        expect(res2.error.cause.formattedError).toHaveProperty(["name"]);
-        expect(res2.error.cause).toHaveProperty(["flattenedError"]);
-      });
+      const res = await child();
+
+      expect(res.ok).toBe(false);
+      assert(!res.ok);
+
+      expect(res.error.code).toBe("OUTPUT_PARSING");
+      assert(res.error.code === "OUTPUT_PARSING");
+      expect(res.error.cause).toHaveProperty(["formattedError"]);
+      expect(res.error.cause.formattedError).toHaveProperty(["name"]);
+      expect(res.error.cause).toHaveProperty(["flattenedError"]);
+
+      const child2 = createSafeFn()
+        .use(parent)
+        .output(z.object({ age: z.number() }))
+        .handler(() => {
+          return ok({ age: 100 });
+        });
+
+      const child3 = createSafeFn()
+        .use(child2)
+        .handler(() => ok({}))
+        .createAction();
+
+      const res2 = await child3();
+      expect(res2.ok).toBe(false);
+      assert(!res2.ok);
+      expect(res2.error.code).toBe("OUTPUT_PARSING");
+      assert(res2.error.code === "OUTPUT_PARSING");
+      expect(res2.error.cause).toHaveProperty(["formattedError"]);
+      expect(res2.error.cause.formattedError).toHaveProperty(["name"]);
+      expect(res2.error.cause).toHaveProperty(["flattenedError"]);
     });
   });
 });

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -273,8 +273,6 @@ describe("runnable-safe-fn", () => {
 
           const args = handlerMock.mock.calls[0]![0];
 
-          console.log(JSON.stringify(args, null, 2));
-
           expect(args.ctx.input).toEqual([
             {
               fullName: "John Doe",

--- a/packages/safe-fn/src/types/handler.ts
+++ b/packages/safe-fn/src/types/handler.ts
@@ -29,7 +29,7 @@ import type {
 /**
  * Convenience type for any handler result.
  */
-export type TAnySafeFnHandlerRes = TMaybePromise<Result<any, any>>;
+export type TAnySafeFnHandlerRes = Result<any, any>;
 
 /**
  * Default handler function. Overridden by `handler()`
@@ -69,10 +69,7 @@ export interface TSafeFnHandlerArgs<
       : TPrettify<Merged>
     : never;
 
-  ctx: {
-    value: TOrFallback<InferSafeFnOkData<TParent, false>, undefined>;
-    input: TCtxInput<TParent>;
-  };
+  ctx: TCtx<TParent>;
 }
 
 /**
@@ -122,11 +119,20 @@ type TSafeFnAsyncGeneratorHandlerFn<
   Result<TSchemaInputOrFallback<TOutputSchema, any>, any>
 >;
 
-export type TCtxInput<TParent extends AnyRunnableSafeFn | undefined> =
-  TParent extends AnyRunnableSafeFn
-    ? [
-        ...TCtxInput<TInferSafeFnParent<TParent>>,
+export interface TCtx<TParent extends AnyRunnableSafeFn | undefined> {
+  value: TOrFallback<InferSafeFnOkData<TParent, false>, undefined>;
+  input: TCtxInput<TParent>;
+}
 
-        TSchemaOutputOrFallback<InferInputSchema<TParent>, undefined>,
-      ]
-    : [];
+export type TCtxInput<TParent extends AnyRunnableSafeFn | undefined> =
+  TIsAny<TParent> extends true
+    ? any
+    : TParent extends AnyRunnableSafeFn
+      ? [
+          ...TCtxInput<TInferSafeFnParent<TParent>>,
+
+          TSchemaOutputOrFallback<InferInputSchema<TParent>, undefined>,
+        ]
+      : [];
+
+type TIsAny<T> = 0 extends 1 & T ? true : false;

--- a/packages/safe-fn/src/types/handler.ts
+++ b/packages/safe-fn/src/types/handler.ts
@@ -69,7 +69,7 @@ export interface TSafeFnHandlerArgs<
       : TPrettify<Merged>
     : never;
 
-  ctx: TCtx<TParent>;
+  ctx: TPrettify<TCtx<TParent>>;
 }
 
 /**
@@ -119,7 +119,7 @@ type TSafeFnAsyncGeneratorHandlerFn<
   Result<TSchemaInputOrFallback<TOutputSchema, any>, any>
 >;
 
-export interface TCtx<TParent extends AnyRunnableSafeFn | undefined> {
+export interface TCtx<in out TParent extends AnyRunnableSafeFn | undefined> {
   value: TOrFallback<InferSafeFnOkData<TParent, false>, undefined>;
   input: TCtxInput<TParent>;
 }

--- a/packages/safe-fn/src/types/handler.ts
+++ b/packages/safe-fn/src/types/handler.ts
@@ -69,7 +69,8 @@ export interface TSafeFnHandlerArgs<
       : TPrettify<Merged>
     : never;
 
-  ctx: TPrettify<TCtx<TParent>>;
+  ctx: TOrFallback<InferSafeFnOkData<TParent, false>, undefined>;
+  ctxInput: TCtxInput<TParent>;
 }
 
 /**
@@ -119,7 +120,7 @@ type TSafeFnAsyncGeneratorHandlerFn<
   Result<TSchemaInputOrFallback<TOutputSchema, any>, any>
 >;
 
-export interface TCtx<in out TParent extends AnyRunnableSafeFn | undefined> {
+interface TCtx<in out TParent extends AnyRunnableSafeFn | undefined> {
   value: TOrFallback<InferSafeFnOkData<TParent, false>, undefined>;
   input: TCtxInput<TParent>;
 }

--- a/packages/safe-fn/src/types/handler.ts
+++ b/packages/safe-fn/src/types/handler.ts
@@ -127,6 +127,6 @@ export type TCtxInput<TParent extends AnyRunnableSafeFn | undefined> =
     ? [
         ...TCtxInput<TInferSafeFnParent<TParent>>,
 
-        TSchemaInputOrFallback<InferInputSchema<TParent>, undefined>,
+        TSchemaOutputOrFallback<InferInputSchema<TParent>, undefined>,
       ]
     : [];

--- a/packages/safe-fn/src/types/internals.ts
+++ b/packages/safe-fn/src/types/internals.ts
@@ -25,3 +25,7 @@ export interface TSafeFnInternals<
   ) => TMaybePromise<TSafeFnHandlerReturn<TOutputSchema>>;
   uncaughtErrorHandler: (error: unknown) => TThrownHandlerRes;
 }
+
+export type TInferSafeFnParent<T> = T extends AnyRunnableSafeFn
+  ? T["_internals"]["parent"]
+  : never;

--- a/packages/safe-fn/src/types/run.ts
+++ b/packages/safe-fn/src/types/run.ts
@@ -6,25 +6,20 @@ import type {
   InferAsyncOkData,
   InferErrError,
 } from "../result";
-import type { AnyRunnableSafeFn } from "../runnable-safe-fn";
+import type { AnyRunnableSafeFn, RunnableSafeFn } from "../runnable-safe-fn";
 import type {
   TAnySafeFnCatchHandlerRes,
   TSafeFnInputParseError,
   TSafeFnOutputParseError,
 } from "../types/error";
-import type { TAnySafeFnHandlerRes } from "../types/handler";
+import type { TAnySafeFnHandlerRes, TCtxInput } from "../types/handler";
 import type {
   TSafeFnInput,
   TSafeFnOutput,
   TSchemaInputOrFallback,
   TSchemaOutputOrFallback,
 } from "../types/schema";
-import type {
-  TDistributeUnion,
-  TODO,
-  TOrFallback,
-  TToTuple,
-} from "../types/util";
+import type { TDistributeUnion, TODO, TToTuple } from "../types/util";
 
 /*
 ################################
@@ -54,6 +49,26 @@ export type InferSafeFnReturn<
     ? ReturnType<T["_runAsAction"]>
     : ReturnType<T["run"]>
   : never;
+
+export type TInferSafeFnInternalRunReturnData<T, TAsAction extends boolean> =
+  T extends RunnableSafeFn<
+    infer TParent,
+    infer TInputSchema,
+    infer TOutputSchema,
+    infer TUnparsedInput,
+    infer THandlerRes,
+    infer TThrownHandlerRes
+  >
+    ? TSafeFnInternalRunReturnData<
+        TParent,
+        TInputSchema,
+        TOutputSchema,
+        TUnparsedInput,
+        THandlerRes,
+        TThrownHandlerRes,
+        TAsAction
+      >
+    : never;
 
 /**
  * @param T the runnable safe function
@@ -222,9 +237,12 @@ export interface TSafeFnInternalRunReturnData<
     >
   >;
   input: TSchemaOutputOrFallback<TInputSchema, undefined>;
-  ctx: TParent extends AnyRunnableSafeFn
-    ? InferSafeFnOkData<TParent, TAsAction>
-    : undefined;
+  ctx: {
+    value: TParent extends AnyRunnableSafeFn
+      ? InferSafeFnOkData<TParent, TAsAction>
+      : undefined;
+    input: TCtxInput<TParent>;
+  };
   unsafeRawInput: TUnparsedInput;
 }
 
@@ -250,7 +268,12 @@ export interface TSafeFnInternalRunReturnError<
   private: {
     input: TSchemaInputOrFallback<TInputSchema, undefined> | undefined;
     ctx:
-      | TOrFallback<InferSafeFnOkData<TParent, TAsAction>, undefined>
+      | {
+          value: TParent extends AnyRunnableSafeFn
+            ? InferSafeFnOkData<TParent, TAsAction>
+            : undefined;
+          input: TCtxInput<TParent>;
+        }
       | undefined;
     unsafeRawInput: TUnparsedInput;
     handlerRes: TODO;

--- a/packages/safe-fn/src/types/run.ts
+++ b/packages/safe-fn/src/types/run.ts
@@ -226,7 +226,7 @@ export interface TSafeFnInternalRunReturnData<
   in out TCatchHandlerRes extends TAnySafeFnCatchHandlerRes,
   in out TAsAction extends boolean,
 > {
-  result: InferAsyncOkData<
+  value: InferAsyncOkData<
     TSafeFnReturn<
       TParent,
       TInputSchema,
@@ -237,12 +237,10 @@ export interface TSafeFnInternalRunReturnData<
     >
   >;
   input: TSchemaOutputOrFallback<TInputSchema, undefined>;
-  ctx: {
-    value: TParent extends AnyRunnableSafeFn
-      ? InferSafeFnOkData<TParent, TAsAction>
-      : undefined;
-    input: TCtxInput<TParent>;
-  };
+  ctx: TParent extends AnyRunnableSafeFn
+    ? InferSafeFnOkData<TParent, TAsAction>
+    : undefined;
+  ctxInput: TCtxInput<TParent>;
   unsafeRawInput: TUnparsedInput;
 }
 
@@ -268,13 +266,11 @@ export interface TSafeFnInternalRunReturnError<
   private: {
     input: TSchemaInputOrFallback<TInputSchema, undefined> | undefined;
     ctx:
-      | {
-          value: TParent extends AnyRunnableSafeFn
-            ? InferSafeFnOkData<TParent, TAsAction>
-            : undefined;
-          input: TCtxInput<TParent>;
-        }
+      | (TParent extends AnyRunnableSafeFn
+          ? InferSafeFnOkData<TParent, TAsAction>
+          : undefined)
       | undefined;
+    ctxInput: TCtxInput<TParent> | undefined;
     unsafeRawInput: TUnparsedInput;
     handlerRes: TODO;
   };

--- a/packages/safe-fn/src/util.ts
+++ b/packages/safe-fn/src/util.ts
@@ -1,12 +1,7 @@
 import { ResultAsync, err, ok } from "neverthrow";
 import { z } from "zod";
 import type { AnyRunnableSafeFn } from "./runnable-safe-fn";
-import type {
-  TSafeFnCallBacks,
-  TSafeFnOnCompleteArgs,
-  TSafeFnOnErrorArgs,
-  TSafeFnOnSuccessArgs,
-} from "./types/callbacks";
+import type { TSafeFnCallBacks } from "./types/callbacks";
 import type { TAnySafeFnHandlerRes } from "./types/handler";
 import type { TSafeFnInput, TSafeFnOutput } from "./types/schema";
 
@@ -15,6 +10,7 @@ import type {
   TSafeFnParseError,
 } from "./types/error";
 import type { TSafeFnInternalRunReturn } from "./types/run";
+import type { TODO } from "./types/util";
 
 const NEXT_JS_ERROR_MESSAGES = ["NEXT_REDIRECT", "NEXT_NOT_FOUND"];
 
@@ -87,17 +83,12 @@ export const runCallbacks = <
         args.callbacks.onSuccess,
         throwFrameworkErrorOrVoid,
       )({
-        unsafeRawInput: res.value.unsafeRawInput,
+        unsafeRawInput: res.value.unsafeRawInput as TODO,
         input: res.value.input,
-        ctx: res.value.ctx,
-        value: res.value.result,
-      } as TSafeFnOnSuccessArgs<
-        TParent,
-        TInputSchema,
-        TOutputSchema,
-        TUnparsedInput,
-        THandlerRes
-      >);
+        ctx: res.value.ctx as TODO,
+        ctxInput: res.value.ctxInput,
+        value: res.value.value,
+      });
       callbackPromises.push(onSuccessPromise);
     } else if (res.isErr() && args.callbacks.onError !== undefined) {
       const onErrorPromise = ResultAsync.fromThrowable(
@@ -105,17 +96,12 @@ export const runCallbacks = <
         throwFrameworkErrorOrVoid,
       )({
         asAction: args.asAction,
-        error: res.error.public,
+        error: res.error.public as TODO,
         ctx: res.error.private.ctx,
+        ctxInput: res.error.private.ctxInput,
         input: res.error.private.input,
-        unsafeRawInput: res.error.private.unsafeRawInput,
-      } as TSafeFnOnErrorArgs<
-        TParent,
-        TInputSchema,
-        TUnparsedInput,
-        THandlerRes,
-        TCatchHandlerRes
-      >);
+        unsafeRawInput: res.error.private.unsafeRawInput as TODO,
+      });
       callbackPromises.push(onErrorPromise);
     }
 
@@ -126,29 +112,26 @@ export const runCallbacks = <
       )({
         asAction: args.asAction,
         result: res.match(
-          (value) => ok(value.result),
+          (value) => ok(value.value),
           (error) => err(error.public),
-        ),
+        ) as TODO,
         ctx: res.match(
           (value) => value.ctx,
           (err) => err.private.ctx,
-        ),
+        ) as TODO,
         input: res.match(
           (value) => value.input,
           (err) => err.private.input,
-        ),
+        ) as TODO,
         unsafeRawInput: res.match(
           (value) => value.unsafeRawInput,
           (err) => err.private.unsafeRawInput,
-        ),
-      } as TSafeFnOnCompleteArgs<
-        TParent,
-        TInputSchema,
-        TOutputSchema,
-        TUnparsedInput,
-        THandlerRes,
-        TCatchHandlerRes
-      >);
+        ) as TODO,
+        ctxInput: res.match(
+          (value) => value.ctxInput,
+          (err) => err.private.ctxInput,
+        ) as TODO,
+      });
       callbackPromises.push(onCompletePromise);
     }
     await ResultAsync.combineWithAllErrors(callbackPromises);

--- a/packages/type-tests/index.ts
+++ b/packages/type-tests/index.ts
@@ -1,8 +1,8 @@
 import { ok } from "neverthrow";
-import { SafeFn } from "safe-fn";
+import { createSafeFn } from "safe-fn";
 import { z } from "zod";
 
-const safeFn1 = SafeFn.new()
+const safeFn1 = createSafeFn()
   .input(
     z.object({
       firstName: z.string(),
@@ -29,7 +29,8 @@ const safeFn1 = SafeFn.new()
 
 const res = safeFn1.run({ firstName: "John", lastName: "Doe" });
 
-const safeFn2 = SafeFn.new(safeFn1)
+const safeFn2 = createSafeFn()
+  .use(safeFn1)
   .input(
     z
       .object({

--- a/packages/type-tests/index.ts
+++ b/packages/type-tests/index.ts
@@ -48,7 +48,7 @@ const safeFn2 = createSafeFn()
   )
   .safeHandler(async function* (args) {
     const age = new Date().getFullYear() - args.input.birthday.getFullYear();
-    return ok({ fullName: args.input.firstName, age });
+    return ok({ fullName: args.ctx.input[0].firstName, age });
   });
 
 const res2 = safeFn2.run({

--- a/packages/type-tests/index.ts
+++ b/packages/type-tests/index.ts
@@ -48,7 +48,7 @@ const safeFn2 = createSafeFn()
   )
   .safeHandler(async function* (args) {
     const age = new Date().getFullYear() - args.input.birthday.getFullYear();
-    return ok({ fullName: args.ctx.input[0].firstName, age });
+    return ok({ fullName: args.ctxInput[0].firstName, age });
   });
 
 const res2 = safeFn2.run({

--- a/packages/type-tests/package.json
+++ b/packages/type-tests/package.json
@@ -6,6 +6,10 @@
     "@repo/typescript-config": "workspace:^",
     "typescript": "^5.5.4"
   },
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "bench-types": "tsc --noEmit --diagnostics"
+  },
   "dependencies": {
     "neverthrow": "^7.1.0",
     "safe-fn": "workspace:^",

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,9 @@
       "persistent": true,
       "cache": false
     },
+    "bench-types": {
+      "dependsOn": ["^build"]
+    },
     "test": {},
     "test:coverage": {},
     "test:watch": {


### PR DESCRIPTION
Switches from merging parsedInput to providing it as `ctxInput` in a typed tuple

- Annoying, may need to parse again to get actual wanted properties 
- slightly more type performant
- old way was not deeply merged (would both really hurt compile/runtime perf)

Maybe look into providing merge function