### PR TITLE
Remove action err

### DIFF
--- a/.changeset/dirty-chicken-whisper.md
+++ b/.changeset/dirty-chicken-whisper.md
@@ -1,0 +1,5 @@
+---
+"safe-fn": patch
+---
+
+- removes asAction, all errors are now stripped by default

--- a/.changeset/short-foxes-care.md
+++ b/.changeset/short-foxes-care.md
@@ -1,0 +1,6 @@
+---
+"safe-fn-react": patch
+"safe-fn": patch
+---
+
+- Rename some Infer types, see docs.

--- a/README.md
+++ b/README.md
@@ -88,7 +88,16 @@ type res = ResultAsync<
   | { code: "NOT_AUTHORIZED" }
   | {
       code: "INPUT_PARSING";
-      cause: z.ZodError<{ title: string; description: string }>;
+      cause: {
+        formattedError: z.ZodFormattedError<{
+          title: string;
+          description: string;
+        }>;
+        flattenedError: z.ZodFlattenedError<{
+          title: string;
+          description: string;
+        }>;
+      };
     }
 >;
 ```

--- a/apps/docs/content/docs/create/callbacks.mdx
+++ b/apps/docs/content/docs/create/callbacks.mdx
@@ -93,7 +93,6 @@ Starts execution after output parsing has completed if you defined a schema, oth
   .onError(async (args) => {
     /*
     (parameter) args: {
-    asAction: boolean
     input: {
         firstName: string;
         lastName: string;
@@ -114,7 +113,6 @@ Starts execution after output parsing has completed if you defined a schema, oth
 
 Starts execution after the first encountered `Err` return while executing your SafeFn. Takes in the following parameters:
 
-- `asAction`: wether the safe-fn was run as an action (`createAction()()`) or not (`run()`). This can be helpful the narrow down the type of `error`.
 - `unsafeRawInput`: the raw input passed when running your SafeFn. Keep in mind this can contain additional properties when using one SafeFn as the parent of another!
 - `input`: the results of parsing `unsafeRawInput` through your input schema if you defined one and parsing was successful, otherwise `undefined`.
 - `ctx`: the `Ok` value of your parent safe-fn if you defined one and execution was successful, otherwise undefined
@@ -128,7 +126,6 @@ Starts execution after the first encountered `Err` return while executing your S
   .onComplete(async (args) => {
     /*
     (parameter) args: {
-    asAction: boolean
     input: {
         firstName: string;
         lastName: string;
@@ -149,7 +146,6 @@ Starts execution after the first encountered `Err` return while executing your S
 
 Starts execution after either `onSuccess()` or `onError()` is **called** (not finished). Takes in the following parameters:
 
-- `asAction`: wether the safe-fn was run as an action (`createAction()()`) or not (`run()`). This can be helpful the narrow down the type of `error`.
 - `unsafeRawInput`: the raw input passed when running your SafeFn. Keep in mind this can contain additional properties when using one SafeFn as the parent of another!
 - `input`: the results of parsing `unsafeRawInput` through your input schema if you defined one and parsing was successful, otherwise `undefined`.
 - `ctx`: the `Ok` value of your parent safe-fn if you defined one and execution was successful, otherwise undefined

--- a/apps/docs/content/docs/create/input-output.mdx
+++ b/apps/docs/content/docs/create/input-output.mdx
@@ -23,23 +23,6 @@ const mySafeFunction = SafeFn.new()
 
 When parsing is not successful, your handler function is not called and the error is returned. As such, the following types are added to the return type of the function:
 
-- when using `run()`
-
-```ts
-ResultAsync<{
-  never,
-  {
-    code: "INPUT_PARSING";
-    cause: z.ZodError<{
-      firstName: string;
-    lastName: string;
-  }>;
-  }
-}>;
-```
-
-- when using `createAction()()` (full errors are stripped here as classes can not be sent via a Server Action and stack traces should not be shipped to the client)
-
 ```ts
 ActionResult<
   never,
@@ -61,6 +44,12 @@ ActionResult<
   }
 >;
 ```
+
+<Callout type="info">
+  The full Zod error is not returned as SafeFn is meant to be used at the edge
+  of your application, stack traces should not be sent to the client and it's
+  not possible to serialize an instance of `Error`s.
+</Callout>
 
 <Callout type="info">
   When using a [parent](/docs/create/chaining), the schema of the Zod error is
@@ -134,20 +123,6 @@ const mySafeFunction = SafeFn.new()
 
 When output parsing is not successful, an `Err` is returned. The following types are added to the return type:
 
-- when using `run()`
-
-```ts
-ResultAsync<{
-  never,
-  {
-    code: "OUTPUT_PARSING";
-    cause: z.ZodError<{ fullName: string }>;
-  };
-}>;
-```
-
-- when using `createAction()()` (full errors are stripped here as classes can not be sent via a Server Action and stack traces should not be shipped to the client)
-
 ```ts
 ActionResult<
   never,
@@ -160,6 +135,12 @@ ActionResult<
   }
 >;
 ```
+
+<Callout type="info">
+  The full Zod error is not returned as SafeFn is meant to be used at the edge
+  of your application, stack traces should not be sent to the client and it's
+  not possible to serialize an instance of `Error`s.
+</Callout>
 
 <Callout type="info">
   When using a [parent](/docs/create/chaining), the schema of the Zod error is

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -109,7 +109,16 @@ type res = ResultAsync<
   | { code: "NOT_AUTHORIZED" }
   | {
       code: "INPUT_PARSING";
-      cause: z.ZodError<{ title: string; description: string }>;
+      cause: {
+        formattedError: z.ZodFormattedError<{
+          title: string;
+          description: string;
+        }>;
+        flattenedError: z.typeToFlattenedError<{
+          title: string;
+          description: string;
+        }>;
+      };
     }
 >;
 ```

--- a/apps/docs/content/docs/run/return-type.mdx
+++ b/apps/docs/content/docs/run/return-type.mdx
@@ -20,17 +20,6 @@ A union that can contain the following errors:
 
 ### Input parsing
 
-When using `.run()`
-
-```ts
-type E = {
-  code: "INPUT_PARSING";
-  cause: z.ZodError<T>;
-};
-```
-
-when using `.createAction()` full errors are stripped as classes can not be sent via a Server Action and stack traces should not be shipped to the client
-
 ```ts
 type E = {
   code: "INPUT_PARSING";
@@ -91,17 +80,6 @@ type E = {
 ```
 
 ### Output parsing
-
-When using `.run()`
-
-```ts
-type E = {
-  code: "OUTPUT_PARSING";
-  cause: z.ZodError<T>;
-};
-```
-
-when using `.createAction()` full errors are stripped as classes can not be sent via a Server Action and stack traces should not be shipped to the client
 
 ```ts
 type E = {
@@ -175,46 +153,7 @@ const child = createSafeFn()
   });
 ```
 
-The return type of `child.run()` will be:
-
-```ts
-type Res = ResultAsync<
-  {
-    childOut: string;
-  },
-  // Merged error from parent and child
-  | {
-      code: "INPUT_PARSING";
-      cause: z.ZodError<{
-        parentIn: string;
-        childIn: string;
-      }>;
-    }
-  // Yielded error in parent
-  | {
-      code: "TOO_LOW!";
-    }
-  // Parent did not specify a catch handler, so default is used
-  | {
-      code: "UNCAUGHT_ERROR";
-      cause: "An uncaught error occurred. You can implement a custom error handler by using `catch()`";
-    }
-  // Specified in child catch handler
-  | {
-      code: "Woops!";
-    }
-  // Output parsing error
-  | {
-      code: "OUTPUT_PARSING";
-      cause: z.ZodError<{
-        parentOut: string;
-        childOut: string;
-      }>;
-    }
->;
-```
-
-The result of calling `child.createAction()` through the `useServerAction()` hook will be:
+The return type of `child.run()` or calling `child.createAction()` through the `useServerAction()` hook will be:
 
 ```ts
 type Res = ResultAsync<

--- a/apps/docs/content/docs/typescript.mdx
+++ b/apps/docs/content/docs/typescript.mdx
@@ -25,7 +25,7 @@ const myActionErr: MyActionErr = {
   ok: false,
   error: {
     code: "DB_ERROR";
-    cause: string;
+    cause: "Database connection failed";
   };
 };
 ```
@@ -72,31 +72,6 @@ type MyActionArgs = InferSafeFnActionArgs<typeof myAction>;
 //   ^ {name: string}
 ```
 
-### InferSafeFnActionError
-
-Infers the error type of an action.
-
-```ts
-const myAction = createSafeFn()
-  .handler(...)
-  .catch(() => err("ooh no" as const))
-  .createAction();
-type MyActionError = InferSafeFnActionError<typeof myAction>;
-//   ^ "ooh no"
-```
-
-### InferSafeFnActionOkData
-
-Infers the ok type of an action.
-
-```ts
-const myAction = createSafeFn()
-  .handler(() => ok("Yay!" as const))
-  .createAction();
-type MyActionOk = InferSafeFnActionOkData<typeof myAction>;
-//   ^ "Yay!"
-```
-
 ### InferSafeFnActionReturn
 
 Infers the return type of an action when calling it directly.
@@ -112,6 +87,31 @@ type MyActionReturn = InferSafeFnActionReturn<typeof myAction>;
 
 Infers the return type of an action.
 
+### InferSafeFnActionReturnData
+
+Infers the ok type of an action.
+
+```ts
+const myAction = createSafeFn()
+  .handler(() => ok("Yay!" as const))
+  .createAction();
+type MyActionOk = InferSafeFnActionOkData<typeof myAction>;
+//   ^ "Yay!"
+```
+
+### InferSafeFnActionReturnError
+
+Infers the error type of an action.
+
+```ts
+const myAction = createSafeFn()
+  .handler(...)
+  .catch(() => err("ooh no" as const))
+  .createAction();
+type MyActionError = InferSafeFnActionReturnError<typeof myAction>;
+//   ^ "ooh no"
+```
+
 ### InferSafeFnArgs
 
 Infers the arguments that need to be passed into `.run()`
@@ -124,32 +124,9 @@ type MySafeFnArgs = InferSafeFnArgs<typeof mySafeFn>;
 //   ^ {name: string}
 ```
 
-### InferSafeFnErrError
-
-Infers the error type of a SafeFn when using `.run()`.
-Boolean parameter is used to specify if the function is run as an action or not.
-
-```ts
-const mySafeFn = createSafeFn()
-  .handler(...)
-  .catch(() => "ooh no" as const);
-type MySafeFnError = InferSafeFnErrError<typeof mySafeFn, true>;
-//   ^ "ooh no"
-```
-
-### InferSafeFnOkData
-
-Infers the ok type of a SafeFn when using `.run()`.
-
-```ts
-const mySafeFn = createSafeFn().handler(() => ok("Yay!" as const));
-type MySafeFnOk = InferSafeFnOkData<typeof mySafeFn>;
-//   ^ "Yay!"
-```
-
 ### InferSafeFnReturn
 
-Infers the return type of a SafeFn when using `.run()`. Boolean parameter is used to specify if the function is run as an action or not.
+Infers the return type of a SafeFn when using `.run()`.
 This is the `ResultAsync` type, this can be converted into a `Result` type by wrapping it in `Await`
 
 ```ts
@@ -160,8 +137,26 @@ type MySafeFnReturn = InferSafeFnReturn<typeof mySafeFn, false>;
 //   ^ ResultAsync<"Yay!", "ooh no">
 type MyAwaitedSafeFnReturn = Awaited<MySafeFnReturn>;
 //   ^ Result<"Yay!", "ooh no">
-type MySafeFnActionReturn = InferSafeFnReturn<typeof mySafeFn, true>;
-//   ^ Promise<ActionResult<"Yay!", "ooh no">>
-type MyAwaitedActionSafeFnReturn = Awaited<MySafeFnReturn>;
-//   ^ ActionResult<"Yay!", "ooh no">
+```
+
+### InferSafeFnReturnData
+
+Infers the ok type of a SafeFn when using `.run()`.
+
+```ts
+const mySafeFn = createSafeFn().handler(() => ok("Yay!" as const));
+type MySafeFnOk = InferSafeFnReturnData<typeof mySafeFn>;
+//   ^ "Yay!"
+```
+
+### InferSafeFnReturnError
+
+Infers the error type of a SafeFn when using `.run()`.
+
+```ts
+const mySafeFn = createSafeFn()
+  .handler(...)
+  .catch(() => "ooh no" as const);
+type MySafeFnError = InferSafeFnReturnError<typeof mySafeFn>;
+//   ^ "ooh no"
 ```

--- a/packages/safe-fn-react/README.md
+++ b/packages/safe-fn-react/README.md
@@ -88,7 +88,16 @@ type res = ResultAsync<
   | { code: "NOT_AUTHORIZED" }
   | {
       code: "INPUT_PARSING";
-      cause: z.ZodError<{ title: string; description: string }>;
+      cause: {
+        formattedError: z.ZodFormattedError<{
+          title: string;
+          description: string;
+        }>;
+        flattenedError: z.ZodFlattenedError<{
+          title: string;
+          description: string;
+        }>;
+      };
     }
 >;
 ```

--- a/packages/safe-fn-react/src/types.ts
+++ b/packages/safe-fn-react/src/types.ts
@@ -1,9 +1,9 @@
 import type {
   AnySafeFnAction,
   InferSafeFnActionArgs,
-  InferSafeFnActionError,
-  InferSafeFnActionOkData,
   InferSafeFnActionReturn,
+  InferSafeFnActionReturnData,
+  InferSafeFnActionReturnError,
 } from "safe-fn";
 
 export type UseServerActionOnStartArgs<TAction extends AnySafeFnAction> = {
@@ -15,7 +15,7 @@ export type UseServerActionOnStart<TAction extends AnySafeFnAction> = (
 
 export type UseServerActionOnErrorArgs<TAction extends AnySafeFnAction> = {
   unsafeRawInput: InferSafeFnActionArgs<TAction>;
-  error: InferSafeFnActionError<TAction>;
+  error: InferSafeFnActionReturnError<TAction>;
 };
 export type UseServerActionOnError<TAction extends AnySafeFnAction> = (
   args: UseServerActionOnErrorArgs<TAction>,
@@ -23,7 +23,7 @@ export type UseServerActionOnError<TAction extends AnySafeFnAction> = (
 
 export type UseServerActionOnSuccessArgs<TAction extends AnySafeFnAction> = {
   unsafeRawInput: InferSafeFnActionArgs<TAction>;
-  value: InferSafeFnActionOkData<TAction>;
+  value: InferSafeFnActionReturnData<TAction>;
 };
 export type UseServerActionOnSuccess<TAction extends AnySafeFnAction> = (
   args: UseServerActionOnSuccessArgs<TAction>,

--- a/packages/safe-fn-react/src/useServerAction.ts
+++ b/packages/safe-fn-react/src/useServerAction.ts
@@ -6,9 +6,9 @@ import {
   type ActionResultToResultAsync,
   type AnySafeFnAction,
   type InferSafeFnActionArgs,
-  type InferSafeFnActionError,
-  type InferSafeFnActionOkData,
   type InferSafeFnActionReturn,
+  type InferSafeFnActionReturnData,
+  type InferSafeFnActionReturnError,
 } from "safe-fn";
 import type { UserServerActionCallbacks } from "./types";
 
@@ -80,7 +80,7 @@ export const useServerAction = <TAction extends AnySafeFnAction>(
         callbackCatch,
       )({
         unsafeRawInput: argsRef.current,
-        value: result.value as InferSafeFnActionOkData<TAction>,
+        value: result.value as InferSafeFnActionReturnData<TAction>,
       });
     } else if (
       result !== undefined &&
@@ -92,7 +92,7 @@ export const useServerAction = <TAction extends AnySafeFnAction>(
         callbackCatch,
       )({
         unsafeRawInput: argsRef.current,
-        error: result.error as InferSafeFnActionError<TAction>,
+        error: result.error as InferSafeFnActionReturnError<TAction>,
       });
     }
 

--- a/packages/safe-fn/README.md
+++ b/packages/safe-fn/README.md
@@ -88,7 +88,16 @@ type res = ResultAsync<
   | { code: "NOT_AUTHORIZED" }
   | {
       code: "INPUT_PARSING";
-      cause: z.ZodError<{ title: string; description: string }>;
+      cause: {
+        formattedError: z.ZodFormattedError<{
+          title: string;
+          description: string;
+        }>;
+        flattenedError: z.ZodFlattenedError<{
+          title: string;
+          description: string;
+        }>;
+      };
     }
 >;
 ```

--- a/packages/safe-fn/src/index.ts
+++ b/packages/safe-fn/src/index.ts
@@ -20,10 +20,10 @@ import type {
   TAnySafeFnAction,
 } from "./types/action";
 import type {
-  InferSafeFnError,
+  InferSafeFnArgs,
+  InferSafeFnReturn,
   InferSafeFnReturnData,
-  InferSafeFnRunArgs,
-  InferSafeFnRunReturn,
+  InferSafeFnReturnError,
 } from "./types/run";
 import type {
   InferInputSchema,
@@ -48,9 +48,9 @@ export type {
   InferSafeFnActionReturn,
   InferSafeFnActionReturnData,
   InferSafeFnActionReturnError,
-  InferSafeFnError,
+  InferSafeFnArgs,
+  InferSafeFnReturn,
   InferSafeFnReturnData,
-  InferSafeFnRunArgs,
-  InferSafeFnRunReturn,
+  InferSafeFnReturnError,
   InferUnparsedInputTuple,
 };

--- a/packages/safe-fn/src/index.ts
+++ b/packages/safe-fn/src/index.ts
@@ -14,16 +14,16 @@ import type { TAnyRunnableSafeFn } from "./runnable-safe-fn";
 
 import type {
   InferSafeFnActionArgs,
-  InferSafeFnActionError,
-  InferSafeFnActionOkData,
   InferSafeFnActionReturn,
+  InferSafeFnActionReturnData,
+  InferSafeFnActionReturnError,
   TAnySafeFnAction,
 } from "./types/action";
 import type {
-  InferSafeFnArgs,
-  InferSafeFnErrError,
-  InferSafeFnOkData,
-  InferSafeFnReturn,
+  InferSafeFnError,
+  InferSafeFnReturnData,
+  InferSafeFnRunArgs,
+  InferSafeFnRunReturn,
 } from "./types/run";
 import type {
   InferInputSchema,
@@ -45,12 +45,12 @@ export type {
   InferInputSchema,
   InferOutputSchema,
   InferSafeFnActionArgs,
-  InferSafeFnActionError,
-  InferSafeFnActionOkData,
   InferSafeFnActionReturn,
-  InferSafeFnArgs,
-  InferSafeFnErrError,
-  InferSafeFnOkData,
-  InferSafeFnReturn,
+  InferSafeFnActionReturnData,
+  InferSafeFnActionReturnError,
+  InferSafeFnError,
+  InferSafeFnReturnData,
+  InferSafeFnRunArgs,
+  InferSafeFnRunReturn,
   InferUnparsedInputTuple,
 };

--- a/packages/safe-fn/src/runnable-safe-fn.ts
+++ b/packages/safe-fn/src/runnable-safe-fn.ts
@@ -58,7 +58,6 @@ export type TInferSafeFnOkData2<T> =
     any,
     any,
     any,
-    any,
     any
   >
     ? TData
@@ -75,46 +74,15 @@ export type TInferSafeFnRunErr<T> =
     any,
     any,
     any,
-    any,
     any
   >
     ? TRunErr
     : never;
 
-export type TInferSafeFnActionErr<T> =
-  T extends TRunnableSafeFn<
-    any,
-    any,
-    infer TActionErr,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any
-  >
-    ? TActionErr
-    : never;
-
 export interface TAnyRunnableSafeFn
-  extends TRunnableSafeFn<
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any
-  > {}
+  extends TRunnableSafeFn<any, any, any, any, any, any, any, any, any, any> {}
 
 type AnyRunnableSafeFn = RunnableSafeFn<
-  any,
   any,
   any,
   any,
@@ -139,7 +107,6 @@ export type TRunnableSafeFnPickArgs =
 export type TRunnableSafeFn<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -154,7 +121,6 @@ export type TRunnableSafeFn<
   RunnableSafeFn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -170,7 +136,6 @@ export type TRunnableSafeFn<
 export class RunnableSafeFn<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -193,7 +158,6 @@ export class RunnableSafeFn<
   readonly _callBacks: TSafeFnCallBacks<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -212,7 +176,6 @@ export class RunnableSafeFn<
     callBacks: TSafeFnCallBacks<
       TData,
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -224,13 +187,7 @@ export class RunnableSafeFn<
     this._callBacks = callBacks;
   }
 
-  createAction(): TSafeFnAction<
-    TData,
-    TRunErr,
-    TActionErr,
-    TOutputSchema,
-    TUnparsedInput
-  > {
+  createAction(): TSafeFnAction<TData, TRunErr, TOutputSchema, TUnparsedInput> {
     // TODO: strip stack traces etc here
     return this._runAsAction.bind(this);
   }
@@ -248,8 +205,6 @@ export class RunnableSafeFn<
   ): TRunnableSafeFn<
     TData,
     | Exclude<TRunErr, TSafeFnDefaultCatchHandlerErrError>
-    | InferErrError<TNewThrownHandlerRes>,
-    | Exclude<TActionErr, TSafeFnDefaultCatchHandlerErrError>
     | InferErrError<TNewThrownHandlerRes>,
     TCtx,
     TCtxInput,
@@ -274,7 +229,6 @@ export class RunnableSafeFn<
   ): TRunnableSafeFn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -301,7 +255,6 @@ export class RunnableSafeFn<
   ): TRunnableSafeFn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -319,7 +272,6 @@ export class RunnableSafeFn<
   onError(
     onErrorFn: TSafeFnOnError<
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -329,7 +281,6 @@ export class RunnableSafeFn<
   ): TRunnableSafeFn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -348,7 +299,6 @@ export class RunnableSafeFn<
     onCompleteFn: TSafeFnOnComplete<
       TData,
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -358,7 +308,6 @@ export class RunnableSafeFn<
   ): TRunnableSafeFn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -470,7 +419,6 @@ export class RunnableSafeFn<
   ): TSafeFnInternalRunReturn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -499,7 +447,6 @@ export class RunnableSafeFn<
     type InternalOk = TSafeFnInternalRunReturnData<
       TData,
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -510,7 +457,6 @@ export class RunnableSafeFn<
     type InternalErr = TSafeFnInternalRunReturnError<
       TData,
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -535,7 +481,6 @@ export class RunnableSafeFn<
                     ({
                       public: e.public as TSafeFnReturnError<
                         TRunErr,
-                        TActionErr,
                         TOutputSchema,
                         TAsAction
                       >,
@@ -638,7 +583,6 @@ export class RunnableSafeFn<
     const internalRes: TSafeFnInternalRunReturn<
       TData,
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -686,7 +630,7 @@ export class RunnableSafeFn<
 
   async _runAsAction(
     ...args: TSafeFnActionArgs<TUnparsedInput>
-  ): TSafeFnActionReturn<TData, TActionErr, TOutputSchema> {
+  ): TSafeFnActionReturn<TData, TRunErr, TOutputSchema> {
     const res = await this._run(args[0], true, false)
       .map((res) => res.value)
       .mapErr((e) => e.public);

--- a/packages/safe-fn/src/runnable-safe-fn.ts
+++ b/packages/safe-fn/src/runnable-safe-fn.ts
@@ -48,38 +48,6 @@ import {
   throwFrameworkErrorOrVoid,
 } from "./util";
 
-export type TInferSafeFnOkData2<T> =
-  T extends TRunnableSafeFn<
-    infer TData,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any
-  >
-    ? TData
-    : never;
-
-export type TInferSafeFnRunErr<T> =
-  T extends TRunnableSafeFn<
-    any,
-    infer TRunErr,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any,
-    any
-  >
-    ? TRunErr
-    : never;
-
 export interface TAnyRunnableSafeFn
   extends TRunnableSafeFn<any, any, any, any, any, any, any, any, any, any> {}
 
@@ -433,7 +401,6 @@ export class RunnableSafeFn<
 
     type InternalOk = TSafeFnInternalRunReturnData<
       TData,
-      TRunErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -441,7 +408,6 @@ export class RunnableSafeFn<
       TUnparsedInput
     >;
     type InternalErr = TSafeFnInternalRunReturnError<
-      TData,
       TRunErr,
       TCtx,
       TCtxInput,

--- a/packages/safe-fn/src/safe-fn-builder.ts
+++ b/packages/safe-fn/src/safe-fn-builder.ts
@@ -5,7 +5,6 @@ import type { InferErrError, InferOkData } from "./result";
 import {
   RunnableSafeFn,
   type TAnyRunnableSafeFn,
-  type TInferSafeFnRunErr,
   type TRunnableSafeFn,
   type TRunnableSafeFnPickArgs,
 } from "./runnable-safe-fn";
@@ -32,7 +31,10 @@ import type {
   TSchemaOutputOrFallback,
 } from "./types/schema";
 
-import type { InferSafeFnOkData } from "./types/run";
+import type {
+  InferSafeFnReturnData,
+  InferSafeFnReturnError,
+} from "./types/run";
 import type {
   AnyObject,
   TIntersectIfNotT,
@@ -148,8 +150,8 @@ export class SafeFnBuilder<
     parent: TNewParent,
   ): TSafeFnBuilder<
     TData,
-    TRunErr | TInferSafeFnRunErr<TNewParent>,
-    InferSafeFnOkData<TNewParent>,
+    TRunErr | InferSafeFnReturnError<TNewParent>,
+    InferSafeFnReturnData<TNewParent>,
     [
       ...TInferCtxInput<TNewParent>,
       TSchemaOutputOrFallback<InferInputSchema<TNewParent>, undefined>,

--- a/packages/safe-fn/src/safe-fn-builder.ts
+++ b/packages/safe-fn/src/safe-fn-builder.ts
@@ -5,7 +5,6 @@ import type { InferErrError, InferOkData } from "./result";
 import {
   RunnableSafeFn,
   type TAnyRunnableSafeFn,
-  type TInferSafeFnActionErr,
   type TInferSafeFnRunErr,
   type TRunnableSafeFn,
   type TRunnableSafeFnPickArgs,
@@ -26,9 +25,7 @@ import type {
   TInferMergedInputSchemaInput,
   TInferMergedParentOutputSchemaInput,
   TSafeFnInput,
-  TSafeFnInputParseActionError,
   TSafeFnInputParseRunError,
-  TSafeFnOutputParseActionError,
   TSafeFnOutputParseRunError,
   TSafeFnUnparsedInput,
   TSchemaInputOrFallback,
@@ -51,7 +48,6 @@ export const createSafeFn = () => {
 type TSafeFnBuilder<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -64,7 +60,6 @@ type TSafeFnBuilder<
   SafeFnBuilder<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -80,7 +75,6 @@ type TSafeFnBuilder<
 export class SafeFnBuilder<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -129,7 +123,6 @@ export class SafeFnBuilder<
   static new(): TSafeFnBuilder<
     never,
     TSafeFnDefaultCatchHandlerErrError,
-    TSafeFnDefaultCatchHandlerErrError,
     undefined,
     [],
     undefined,
@@ -156,7 +149,6 @@ export class SafeFnBuilder<
   ): TSafeFnBuilder<
     TData,
     TRunErr | TInferSafeFnRunErr<TNewParent>,
-    TActionErr | TInferSafeFnActionErr<TNewParent>,
     InferSafeFnOkData<TNewParent>,
     [
       ...TInferCtxInput<TNewParent>,
@@ -181,14 +173,6 @@ export class SafeFnBuilder<
     TData,
     | Exclude<TRunErr, { code: "INPUT_PARSING" }>
     | TSafeFnInputParseRunError<
-        TIntersectIfNotT<
-          TMergedInputSchemaInput,
-          z.input<TNewInputSchema>,
-          undefined
-        >
-      >,
-    | Exclude<TActionErr, { code: "INPUT_PARSING" }>
-    | TSafeFnInputParseActionError<
         TIntersectIfNotT<
           TMergedInputSchemaInput,
           z.input<TNewInputSchema>,
@@ -222,7 +206,6 @@ export class SafeFnBuilder<
   unparsedInput<TNewUnparsedInput>(): TSafeFnBuilder<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -239,7 +222,6 @@ export class SafeFnBuilder<
     return this as unknown as SafeFnBuilder<
       TData,
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -261,14 +243,6 @@ export class SafeFnBuilder<
     TData,
     | Exclude<TRunErr, { code: "OUTPUT_PARSING" }>
     | TSafeFnOutputParseRunError<
-        TIntersectIfNotT<
-          TMergedParentOutputSchemaInput,
-          z.input<TNewOutputSchema>,
-          undefined
-        >
-      >,
-    | Exclude<TActionErr, { code: "OUTPUT_PARSING" }>
-    | TSafeFnOutputParseActionError<
         TIntersectIfNotT<
           TMergedParentOutputSchemaInput,
           z.input<TNewOutputSchema>,
@@ -299,7 +273,6 @@ export class SafeFnBuilder<
   ): TRunnableSafeFn<
     InferOkData<TNewHandlerResult>,
     TRunErr | InferErrError<TNewHandlerResult>,
-    TActionErr | InferErrError<TNewHandlerResult>,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -338,7 +311,6 @@ export class SafeFnBuilder<
   ): TRunnableSafeFn<
     InferOkData<GeneratorResult>,
     TRunErr | InferErrError<GeneratorResult> | InferErrError<YieldErr>,
-    TActionErr | InferErrError<GeneratorResult> | InferErrError<YieldErr>,
     TCtx,
     TCtxInput,
     TInputSchema,

--- a/packages/safe-fn/src/safe-fn-builder.ts
+++ b/packages/safe-fn/src/safe-fn-builder.ts
@@ -25,8 +25,8 @@ import type {
   TInferMergedInputSchemaInput,
   TInferMergedParentOutputSchemaInput,
   TSafeFnInput,
-  TSafeFnInputParseRunError,
-  TSafeFnOutputParseRunError,
+  TSafeFnInputParseErrorNoZod,
+  TSafeFnOutputParseErrorNoZod,
   TSafeFnUnparsedInput,
   TSchemaInputOrFallback,
   TSchemaOutputOrFallback,
@@ -172,7 +172,7 @@ export class SafeFnBuilder<
   ): TSafeFnBuilder<
     TData,
     | Exclude<TRunErr, { code: "INPUT_PARSING" }>
-    | TSafeFnInputParseRunError<
+    | TSafeFnInputParseErrorNoZod<
         TIntersectIfNotT<
           TMergedInputSchemaInput,
           z.input<TNewInputSchema>,
@@ -242,7 +242,7 @@ export class SafeFnBuilder<
   ): TSafeFnBuilder<
     TData,
     | Exclude<TRunErr, { code: "OUTPUT_PARSING" }>
-    | TSafeFnOutputParseRunError<
+    | TSafeFnOutputParseErrorNoZod<
         TIntersectIfNotT<
           TMergedParentOutputSchemaInput,
           z.input<TNewOutputSchema>,

--- a/packages/safe-fn/src/safe-fn.test.ts
+++ b/packages/safe-fn/src/safe-fn.test.ts
@@ -1,6 +1,6 @@
 import { err, ok, type Result } from "neverthrow";
 import { assert, describe, expect, test, vi, type Mock } from "vitest";
-import { z, ZodError } from "zod";
+import { z } from "zod";
 import type { TAnyRunnableSafeFn } from "./runnable-safe-fn";
 import { createSafeFn, SafeFnBuilder } from "./safe-fn-builder";
 import type { TInferSafeFnCallbacks } from "./types/callbacks";
@@ -258,9 +258,8 @@ describe("runnable-safe-fn", () => {
           assert(res.isErr());
           expect(res.error.code).toBe("INPUT_PARSING");
           assert(res.error.code === "INPUT_PARSING");
-          expect(res.error.cause).toBeInstanceOf(ZodError);
-          expect(res.error.cause.format().lastName).toBeDefined();
-          expect(res.error.cause.format().name).toBeDefined();
+          expect(res.error.cause.formattedError.lastName).toBeDefined();
+          expect(res.error.cause.formattedError.name).toBeDefined();
         });
 
         test("should pass parent input in array", async () => {
@@ -387,9 +386,8 @@ describe("runnable-safe-fn", () => {
         assert(res.isErr());
         expect(res.error.code).toBe("OUTPUT_PARSING");
         assert(res.error.code === "OUTPUT_PARSING");
-        expect(res.error.cause).toBeInstanceOf(ZodError);
-        expect(res.error.cause.format().lastName).toBeDefined();
-        expect(res.error.cause.format().name).toBeDefined();
+        expect(res.error.cause.formattedError.lastName).toBeDefined();
+        expect(res.error.cause.formattedError.name).toBeDefined();
       });
     });
 
@@ -674,7 +672,6 @@ describe("runnable-safe-fn", () => {
 
       test("onComplete", () => {
         expect(callbackMocks.onComplete).toHaveBeenCalledWith({
-          asAction: false,
           input: { name: "John" },
           unsafeRawInput: { name: "John", age: 100 },
           ctx: "Parent!",
@@ -733,7 +730,6 @@ describe("runnable-safe-fn", () => {
 
       test("onError", () => {
         expect(callbackMocks.onError).toHaveBeenCalledWith({
-          asAction: false,
           error: "Woops!",
           ctx: "Parent!",
           ctxInput: [{ age: 100 }],
@@ -744,7 +740,6 @@ describe("runnable-safe-fn", () => {
 
       test("onComplete", () => {
         expect(callbackMocks.onComplete).toHaveBeenCalledWith({
-          asAction: false,
           input: { name: "John" },
           unsafeRawInput: { name: "John", age: 100 },
           ctx: "Parent!",
@@ -809,7 +804,6 @@ describe("runnable-safe-fn", () => {
 
       test("onError", () => {
         expect(callbackMocks.onError).toHaveBeenCalledWith({
-          asAction: false,
           error: "Parent!",
           ctx: undefined,
           ctxInput: [{ age: 100 }],
@@ -820,7 +814,6 @@ describe("runnable-safe-fn", () => {
 
       test("onComplete", () => {
         expect(callbackMocks.onComplete).toHaveBeenCalledWith({
-          asAction: false,
           input: undefined,
           unsafeRawInput: { name: "John", age: 100 },
           ctx: undefined,
@@ -884,12 +877,12 @@ describe("runnable-safe-fn", () => {
         const args = callbackMocks.onError.mock
           .calls[0]![0] as CallbackArgs["onError"];
 
-        assert(args.asAction === false);
         assert(args.ctx === undefined);
         assert(args.input === undefined);
         assert(args.error.code === "INPUT_PARSING");
-        assert(args.error.cause instanceof ZodError);
-        expect(args.error.cause.format()).toHaveProperty(["age"]);
+        expect(args.error.cause.formattedError.age).toBeDefined();
+        // Doesn't reach child parsing
+        expect(args.error.cause.formattedError.name).not.toBeDefined();
       });
 
       test("onComplete", () => {
@@ -897,13 +890,13 @@ describe("runnable-safe-fn", () => {
         const args = callbackMocks.onComplete.mock
           .calls[0]![0] as CallbackArgs["onComplete"];
 
-        assert(args.asAction === false);
         assert(args.ctx === undefined);
         assert(args.input === undefined);
         assert(args.result.isErr());
         assert(args.result.error.code === "INPUT_PARSING");
-        assert(args.result.error.cause instanceof ZodError);
-        expect(args.result.error.cause.format()).toHaveProperty(["age"]);
+        expect(args.result.error.cause.formattedError.age).toBeDefined();
+        // Doesn't reach child parsing
+        expect(args.result.error.cause.formattedError.name).not.toBeDefined();
       });
     });
   });

--- a/packages/safe-fn/src/types/action.ts
+++ b/packages/safe-fn/src/types/action.ts
@@ -45,7 +45,7 @@ export type InferSafeFnActionArgs<T extends TAnySafeFnAction> =
  * Return type:
  * - The `.value` type of the returned `ActionResult` assuming it's ok
  */
-export type InferSafeFnActionOkData<T extends TAnySafeFnAction> =
+export type InferSafeFnActionReturnData<T extends TAnySafeFnAction> =
   InferActionOkData<InferSafeFnActionReturn<T>>;
 
 /**
@@ -55,7 +55,7 @@ export type InferSafeFnActionOkData<T extends TAnySafeFnAction> =
  * Return type:
  * - The `.error` type of the returned `ActionResult` assuming it's not ok
  */
-export type InferSafeFnActionError<T extends TAnySafeFnAction> =
+export type InferSafeFnActionReturnError<T extends TAnySafeFnAction> =
   InferActionErrError<InferSafeFnActionReturn<T>>;
 
 /*

--- a/packages/safe-fn/src/types/action.ts
+++ b/packages/safe-fn/src/types/action.ts
@@ -66,25 +66,24 @@ export type InferSafeFnActionError<T extends TAnySafeFnAction> =
 ################################
 */
 
-export type TAnySafeFnAction = TSafeFnAction<any, any, any, any, any>;
+export type TAnySafeFnAction = TSafeFnAction<any, any, any, any>;
 
 export type TSafeFnActionArgs<T extends TSafeFnUnparsedInput> =
   TSafeFnRunArgs<T>;
 
 export type TSafeFnActionReturn<
   in out TData,
-  in out TActionErr,
+  in out TRunError,
   in out TOutputSchema extends TSafeFnOutput,
 > = Promise<
-  ActionResult<TSchemaOutputOrFallback<TOutputSchema, TData>, TActionErr>
+  ActionResult<TSchemaOutputOrFallback<TOutputSchema, TData>, TRunError>
 >;
 
 export type TSafeFnAction<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TOutputSchema extends TSafeFnOutput,
   in out TUnparsedInput extends TSafeFnUnparsedInput,
 > = (
   ...args: TSafeFnActionArgs<TUnparsedInput>
-) => TSafeFnActionReturn<TData, TActionErr, TOutputSchema>;
+) => TSafeFnActionReturn<TData, TRunErr, TOutputSchema>;

--- a/packages/safe-fn/src/types/callbacks.ts
+++ b/packages/safe-fn/src/types/callbacks.ts
@@ -1,11 +1,7 @@
 import type { Result } from "neverthrow";
 import type { TRunnableSafeFn } from "../runnable-safe-fn";
 import type { AnyCtxInput, TSafeFnHandlerArgs } from "./handler";
-import type {
-  TSafeFnActionError,
-  TSafeFnReturnData,
-  TSafeFnRunError,
-} from "./run";
+import type { TSafeFnReturnData, TSafeFnRunError } from "./run";
 import type {
   TSafeFnInput,
   TSafeFnOutput,
@@ -24,7 +20,6 @@ export type TInferSafeFnCallbacks<T> =
   T extends TRunnableSafeFn<
     infer TData,
     infer TRunErr,
-    infer TActionErr,
     infer TCtx,
     infer TCtxInput,
     infer TInputSchema,
@@ -37,7 +32,6 @@ export type TInferSafeFnCallbacks<T> =
     ? TSafeFnCallBacks<
         TData,
         TRunErr,
-        TActionErr,
         TCtx,
         TCtxInput,
         TInputSchema,
@@ -49,7 +43,6 @@ export type TInferSafeFnCallbacks<T> =
 export interface TSafeFnCallBacks<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -70,7 +63,6 @@ export interface TSafeFnCallBacks<
   onError:
     | TSafeFnOnError<
         TRunErr,
-        TActionErr,
         TCtx,
         TCtxInput,
         TInputSchema,
@@ -82,7 +74,6 @@ export interface TSafeFnCallBacks<
     | TSafeFnOnComplete<
         TData,
         TRunErr,
-        TActionErr,
         TCtx,
         TCtxInput,
         TInputSchema,
@@ -132,42 +123,19 @@ type TToOptionalSafeFnArgs<T> = {
 
 type TSafeFnOnErrorArgs<
   TRunError,
-  TActionError,
   TCtx,
   TCtxInput extends AnyCtxInput,
   TInputSchema extends TSafeFnInput,
   TOutputSchema extends TSafeFnOutput,
   TUnparsedInput extends TSafeFnUnparsedInput,
-> =
-  | TSafeFnOnErrorActionArgs<
-      TActionError,
-      TCtx,
-      TCtxInput,
-      TInputSchema,
-      TOutputSchema,
-      TUnparsedInput
-    >
-  | TSafeFnOnErrorNonActionArgs<
-      TRunError,
-      TCtx,
-      TCtxInput,
-      TInputSchema,
-      TOutputSchema,
-      TUnparsedInput
-    >;
-interface TSafeFnOnErrorActionArgs<
-  in out TActionError,
-  in out TCtx,
-  in out TCtxInput extends AnyCtxInput,
-  in out TInputSchema extends TSafeFnInput,
-  in out TOutputSchema extends TSafeFnOutput,
-  in out TUnparsedInput extends TSafeFnUnparsedInput,
-> extends TToOptionalSafeFnArgs<
-    TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput>
-  > {
-  asAction: true;
-  error: TSafeFnActionError<TActionError, TOutputSchema>;
-}
+> = TSafeFnOnErrorNonActionArgs<
+  TRunError,
+  TCtx,
+  TCtxInput,
+  TInputSchema,
+  TOutputSchema,
+  TUnparsedInput
+>;
 
 interface TSafeFnOnErrorNonActionArgs<
   in out TRunError,
@@ -185,7 +153,6 @@ interface TSafeFnOnErrorNonActionArgs<
 
 export type TSafeFnOnError<
   in out TRunError,
-  in out TActionError,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -194,7 +161,6 @@ export type TSafeFnOnError<
 > = (
   args: TSafeFnOnErrorArgs<
     TRunError,
-    TActionError,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -206,7 +172,6 @@ export type TSafeFnOnError<
 type TSafeFnOnCompleteArgs<
   TData,
   TRunErr,
-  TActionErr,
   TCtx,
   TCtxInput extends AnyCtxInput,
   TInputSchema extends TSafeFnInput,
@@ -215,7 +180,6 @@ type TSafeFnOnCompleteArgs<
 > =
   | TSafeFnOnCompleteErrorArgs<
       TRunErr,
-      TActionErr,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -233,29 +197,19 @@ type TSafeFnOnCompleteArgs<
 
 type TSafeFnOnCompleteErrorArgs<
   TRunErr,
-  TActionErr,
   TCtx,
   TCtxInput extends AnyCtxInput,
   TInputSchema extends TSafeFnInput,
   TOutputSchema extends TSafeFnInput,
   TUnparsedInput extends TSafeFnUnparsedInput,
-> =
-  | TSafeFnOnCompleteErrorActionArgs<
-      TActionErr,
-      TCtx,
-      TCtxInput,
-      TInputSchema,
-      TOutputSchema,
-      TUnparsedInput
-    >
-  | TSafeFnOnCompleteErrorNonActionArgs<
-      TRunErr,
-      TCtx,
-      TCtxInput,
-      TInputSchema,
-      TOutputSchema,
-      TUnparsedInput
-    >;
+> = TSafeFnOnCompleteErrorNonActionArgs<
+  TRunErr,
+  TCtx,
+  TCtxInput,
+  TInputSchema,
+  TOutputSchema,
+  TUnparsedInput
+>;
 
 interface TSafeFnOnCompleteSuccessArgs<
   in out TData,
@@ -267,20 +221,6 @@ interface TSafeFnOnCompleteSuccessArgs<
 > extends TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput> {
   asAction: boolean;
   result: Result<TSafeFnReturnData<TData, TOutputSchema>, never>;
-}
-
-interface TSafeFnOnCompleteErrorActionArgs<
-  in out TActionError,
-  in out TCtx,
-  in out TCtxInput extends AnyCtxInput,
-  in out TInputSchema extends TSafeFnInput,
-  in out TOutputSchema extends TSafeFnInput,
-  in out TUnparsedInput extends TSafeFnUnparsedInput,
-> extends TToOptionalSafeFnArgs<
-    TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput>
-  > {
-  asAction: true;
-  result: Result<never, TSafeFnActionError<TActionError, TOutputSchema>>;
 }
 
 interface TSafeFnOnCompleteErrorNonActionArgs<
@@ -300,7 +240,6 @@ interface TSafeFnOnCompleteErrorNonActionArgs<
 export type TSafeFnOnComplete<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -310,7 +249,6 @@ export type TSafeFnOnComplete<
   args: TSafeFnOnCompleteArgs<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,

--- a/packages/safe-fn/src/types/callbacks.ts
+++ b/packages/safe-fn/src/types/callbacks.ts
@@ -147,7 +147,6 @@ interface TSafeFnOnErrorNonActionArgs<
 > extends TToOptionalSafeFnArgs<
     TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput>
   > {
-  asAction: false;
   error: TSafeFnRunError<TRunError, TOutputSchema>;
 }
 
@@ -195,22 +194,6 @@ type TSafeFnOnCompleteArgs<
       TUnparsedInput
     >;
 
-type TSafeFnOnCompleteErrorArgs<
-  TRunErr,
-  TCtx,
-  TCtxInput extends AnyCtxInput,
-  TInputSchema extends TSafeFnInput,
-  TOutputSchema extends TSafeFnInput,
-  TUnparsedInput extends TSafeFnUnparsedInput,
-> = TSafeFnOnCompleteErrorNonActionArgs<
-  TRunErr,
-  TCtx,
-  TCtxInput,
-  TInputSchema,
-  TOutputSchema,
-  TUnparsedInput
->;
-
 interface TSafeFnOnCompleteSuccessArgs<
   in out TData,
   in out TCtx,
@@ -219,11 +202,10 @@ interface TSafeFnOnCompleteSuccessArgs<
   in out TOutputSchema extends TSafeFnInput,
   in out TUnparsedInput extends TSafeFnUnparsedInput,
 > extends TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput> {
-  asAction: boolean;
   result: Result<TSafeFnReturnData<TData, TOutputSchema>, never>;
 }
 
-interface TSafeFnOnCompleteErrorNonActionArgs<
+interface TSafeFnOnCompleteErrorArgs<
   in out TRunError,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
@@ -233,7 +215,6 @@ interface TSafeFnOnCompleteErrorNonActionArgs<
 > extends TToOptionalSafeFnArgs<
     TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput>
   > {
-  asAction: false;
   result: Result<never, TSafeFnRunError<TRunError, TOutputSchema>>;
 }
 

--- a/packages/safe-fn/src/types/callbacks.ts
+++ b/packages/safe-fn/src/types/callbacks.ts
@@ -1,7 +1,7 @@
 import type { Result } from "neverthrow";
 import type { TRunnableSafeFn } from "../runnable-safe-fn";
 import type { AnyCtxInput, TSafeFnHandlerArgs } from "./handler";
-import type { TSafeFnReturnData, TSafeFnRunError } from "./run";
+import type { TSafeFnReturnData, TSafeFnReturnError } from "./run";
 import type {
   TSafeFnInput,
   TSafeFnOutput,
@@ -147,7 +147,7 @@ interface TSafeFnOnErrorNonActionArgs<
 > extends TToOptionalSafeFnArgs<
     TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput>
   > {
-  error: TSafeFnRunError<TRunError, TOutputSchema>;
+  error: TSafeFnReturnError<TRunError, TOutputSchema>;
 }
 
 export type TSafeFnOnError<
@@ -215,7 +215,7 @@ interface TSafeFnOnCompleteErrorArgs<
 > extends TToOptionalSafeFnArgs<
     TSafeFnHandlerArgs<TCtx, TCtxInput, TInputSchema, TUnparsedInput>
   > {
-  result: Result<never, TSafeFnRunError<TRunError, TOutputSchema>>;
+  result: Result<never, TSafeFnReturnError<TRunError, TOutputSchema>>;
 }
 
 export type TSafeFnOnComplete<

--- a/packages/safe-fn/src/types/run.ts
+++ b/packages/safe-fn/src/types/run.ts
@@ -1,6 +1,5 @@
 import type { ResultAsync } from "neverthrow";
-import type { InferAsyncErrError } from "../result";
-import type { TAnyRunnableSafeFn, TRunnableSafeFn } from "../runnable-safe-fn";
+import type { TRunnableSafeFn } from "../runnable-safe-fn";
 import type { AnyCtxInput } from "../types/handler";
 import type {
   TSafeFnInput,
@@ -25,7 +24,7 @@ import type { TODO } from "../types/util";
  * Return type:
  * - The type of the arguments of the safe function passed to `run()`
  */
-export type InferSafeFnRunArgs<T> =
+export type InferSafeFnArgs<T> =
   T extends TRunnableSafeFn<
     any,
     any,
@@ -48,7 +47,7 @@ export type InferSafeFnRunArgs<T> =
  * Return type:
  * - The return typ, a `ResultAsync`
  */
-export type InferSafeFnRunReturn<T> =
+export type InferSafeFnReturn<T> =
   T extends TRunnableSafeFn<
     infer TData,
     infer TRunErr,
@@ -102,17 +101,6 @@ export type InferSafeFnReturnError<T> =
   >
     ? TRunErr
     : never;
-
-/**
- * Type params:
- * - `T`: The runnable safe function
- *
- * Return type:
- * - The type of the `.error` of the return type of the safe function after unsuccessful execution.
- */
-export type InferSafeFnError<T extends TAnyRunnableSafeFn> = InferAsyncErrError<
-  InferSafeFnRunReturn<T>
->;
 
 /*
 ################################

--- a/packages/safe-fn/src/types/run.ts
+++ b/packages/safe-fn/src/types/run.ts
@@ -40,7 +40,6 @@ export type InferSafeFnArgs<T> =
     any,
     any,
     any,
-    any,
     infer TUnparsedInput,
     any
   >
@@ -59,7 +58,6 @@ export type InferSafeFnReturn<T, TAsAction extends boolean> =
   T extends TRunnableSafeFn<
     infer TData,
     infer TRunErr,
-    infer TActionErr,
     any,
     any,
     any,
@@ -70,7 +68,7 @@ export type InferSafeFnReturn<T, TAsAction extends boolean> =
     any
   >
     ? TAsAction extends true
-      ? TSafeFnActionReturn<TData, TActionErr, TOutputSchema>
+      ? TSafeFnActionReturn<TData, TRunErr, TOutputSchema>
       : TSafeFnRunReturn<TData, TRunErr, TOutputSchema>
     : never;
 
@@ -84,7 +82,6 @@ export type InferSafeFnReturn<T, TAsAction extends boolean> =
 export type InferSafeFnOkData<T> =
   T extends TRunnableSafeFn<
     infer TData,
-    any,
     any,
     any,
     any,
@@ -128,29 +125,21 @@ export type TSafeFnReturnData<TData, TOutputSchema extends TSafeFnOutput> = [
   : TSchemaOutputOrFallback<TOutputSchema, TData>;
 
 export type TSafeFnRunError<TRunErr, TOutputSchema> = TRunErr;
-export type TSafeFnActionError<TActionErr, TOutputSchema> = TActionErr;
 
 export type TSafeFnRunArgs<T extends TSafeFnUnparsedInput> = T;
 
 export interface TSafeFnReturn<
   in out TData,
   in out TRunError,
-  in out TActionError,
   in out TOutputSchema extends TSafeFnOutput,
   in out TAsAction extends boolean,
 > extends ResultAsync<
     TSafeFnReturnData<TData, TOutputSchema>,
-    TSafeFnReturnError<TRunError, TActionError, TOutputSchema, TAsAction>
+    TSafeFnReturnError<TRunError, TOutputSchema, TAsAction>
   > {}
 
-export type TSafeFnReturnError<
-  TRunError,
-  TActionError,
-  TOutputSchema,
-  TAsAction,
-> = TAsAction extends true
-  ? TSafeFnActionError<TActionError, TOutputSchema>
-  : TSafeFnRunError<TRunError, TOutputSchema>;
+export type TSafeFnReturnError<TRunError, TOutputSchema, TAsAction> =
+  TSafeFnRunError<TRunError, TOutputSchema>;
 
 export interface TSafeFnRunReturn<
   in out TData,
@@ -164,7 +153,6 @@ export interface TSafeFnRunReturn<
 export interface TSafeFnInternalRunReturn<
   in out TData,
   in out TRunError,
-  in out TActionError,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -175,7 +163,6 @@ export interface TSafeFnInternalRunReturn<
     TSafeFnInternalRunReturnData<
       TData,
       TRunError,
-      TActionError,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -186,7 +173,6 @@ export interface TSafeFnInternalRunReturn<
     TSafeFnInternalRunReturnError<
       TData,
       TRunError,
-      TActionError,
       TCtx,
       TCtxInput,
       TInputSchema,
@@ -199,7 +185,6 @@ export interface TSafeFnInternalRunReturn<
 export interface TSafeFnInternalRunReturnData<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -208,7 +193,7 @@ export interface TSafeFnInternalRunReturnData<
   in out TAsAction extends boolean,
 > {
   value: InferAsyncOkData<
-    TSafeFnReturn<TData, TRunErr, TActionErr, TOutputSchema, TAsAction>
+    TSafeFnReturn<TData, TRunErr, TOutputSchema, TAsAction>
   >;
   input: TSchemaOutputOrFallback<TInputSchema, undefined>;
   ctx: TCtx;
@@ -219,7 +204,6 @@ export interface TSafeFnInternalRunReturnData<
 export interface TSafeFnInternalRunReturnError<
   in out TData,
   in out TRunErr,
-  in out TActionErr,
   in out TCtx,
   in out TCtxInput extends AnyCtxInput,
   in out TInputSchema extends TSafeFnInput,
@@ -228,7 +212,7 @@ export interface TSafeFnInternalRunReturnError<
   in out TAsAction extends boolean,
 > {
   public: InferAsyncErrError<
-    TSafeFnReturn<TData, TRunErr, TActionErr, TOutputSchema, TAsAction>
+    TSafeFnReturn<TData, TRunErr, TOutputSchema, TAsAction>
   >;
   private: {
     input: TSchemaInputOrFallback<TInputSchema, undefined> | undefined;

--- a/packages/safe-fn/src/types/run.ts
+++ b/packages/safe-fn/src/types/run.ts
@@ -132,14 +132,15 @@ export interface TSafeFnReturn<
   in out TData,
   in out TRunError,
   in out TOutputSchema extends TSafeFnOutput,
-  in out TAsAction extends boolean,
 > extends ResultAsync<
     TSafeFnReturnData<TData, TOutputSchema>,
-    TSafeFnReturnError<TRunError, TOutputSchema, TAsAction>
+    TSafeFnReturnError<TRunError, TOutputSchema>
   > {}
 
-export type TSafeFnReturnError<TRunError, TOutputSchema, TAsAction> =
-  TSafeFnRunError<TRunError, TOutputSchema>;
+export type TSafeFnReturnError<TRunError, TOutputSchema> = TSafeFnRunError<
+  TRunError,
+  TOutputSchema
+>;
 
 export interface TSafeFnRunReturn<
   in out TData,
@@ -158,7 +159,6 @@ export interface TSafeFnInternalRunReturn<
   in out TInputSchema extends TSafeFnInput,
   in out TOutputSchema extends TSafeFnOutput,
   in out TUnparsedInput,
-  in out TAsAction extends boolean,
 > extends ResultAsync<
     TSafeFnInternalRunReturnData<
       TData,
@@ -167,8 +167,7 @@ export interface TSafeFnInternalRunReturn<
       TCtxInput,
       TInputSchema,
       TOutputSchema,
-      TUnparsedInput,
-      TAsAction
+      TUnparsedInput
     >,
     TSafeFnInternalRunReturnError<
       TData,
@@ -177,8 +176,7 @@ export interface TSafeFnInternalRunReturn<
       TCtxInput,
       TInputSchema,
       TOutputSchema,
-      TUnparsedInput,
-      TAsAction
+      TUnparsedInput
     >
   > {}
 
@@ -190,11 +188,8 @@ export interface TSafeFnInternalRunReturnData<
   in out TInputSchema extends TSafeFnInput,
   in out TOutputSchema extends TSafeFnOutput,
   in out TUnparsedInput,
-  in out TAsAction extends boolean,
 > {
-  value: InferAsyncOkData<
-    TSafeFnReturn<TData, TRunErr, TOutputSchema, TAsAction>
-  >;
+  value: InferAsyncOkData<TSafeFnReturn<TData, TRunErr, TOutputSchema>>;
   input: TSchemaOutputOrFallback<TInputSchema, undefined>;
   ctx: TCtx;
   ctxInput: TCtxInput;
@@ -209,11 +204,8 @@ export interface TSafeFnInternalRunReturnError<
   in out TInputSchema extends TSafeFnInput,
   in out TOutputSchema extends TSafeFnOutput,
   in out TUnparsedInput,
-  in out TAsAction extends boolean,
 > {
-  public: InferAsyncErrError<
-    TSafeFnReturn<TData, TRunErr, TOutputSchema, TAsAction>
-  >;
+  public: InferAsyncErrError<TSafeFnReturn<TData, TRunErr, TOutputSchema>>;
   private: {
     input: TSchemaInputOrFallback<TInputSchema, undefined> | undefined;
     ctx: TCtx;

--- a/packages/safe-fn/src/types/schema.ts
+++ b/packages/safe-fn/src/types/schema.ts
@@ -22,7 +22,6 @@ export type InferInputSchema<T> =
     any,
     any,
     any,
-    any,
     infer TInputSchema,
     any,
     any,
@@ -42,7 +41,6 @@ export type InferInputSchema<T> =
  */
 export type InferOutputSchema<T> =
   T extends TRunnableSafeFn<
-    any,
     any,
     any,
     any,
@@ -74,7 +72,6 @@ export type InferUnparsedInputTuple<T> =
     any,
     any,
     any,
-    any,
     infer TUnparsed,
     any
   >
@@ -83,7 +80,6 @@ export type InferUnparsedInputTuple<T> =
 
 export type TInferMergedInputSchemaInput<T> =
   T extends TRunnableSafeFn<
-    any,
     any,
     any,
     any,
@@ -106,7 +102,6 @@ export type TInferMergedParentOutputSchemaInput<T> =
     any,
     any,
     any,
-    any,
     infer TOutputSchema,
     infer MergedOutputSchemaInput,
     any,
@@ -121,7 +116,6 @@ export type TInferMergedParentOutputSchemaInput<T> =
 
 export type TInferCtxInput<T> =
   T extends TRunnableSafeFn<
-    any,
     any,
     any,
     any,

--- a/packages/safe-fn/src/types/schema.ts
+++ b/packages/safe-fn/src/types/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { TRunnableSafeFn } from "../runnable-safe-fn";
-import type { AnyObject, TIntersectIfNotT } from "./util";
+import type { AnyValue, TIntersectIfNotT, TPrettify } from "./util";
 
 /*
 ################################
@@ -154,58 +154,22 @@ export type TSchemaOutputOrFallback<
   TFallback,
 > = TSchema extends z.ZodTypeAny ? z.output<TSchema> : TFallback;
 
-export type TSafeFnParseError<
-  TSchemaInput extends AnyObject,
-  TAsAction extends boolean,
-> = TAsAction extends true
-  ? {
-      formattedError: z.ZodFormattedError<TSchemaInput>;
-      flattenedError: z.typeToFlattenedError<TSchemaInput>;
-    }
-  : z.ZodError<TSchemaInput>;
-
-export type TSafeFnInputParseError<
-  TInputSchema extends TSafeFnInput,
-  TAsAction extends boolean,
-> = TInputSchema extends z.ZodTypeAny
-  ? {
-      code: "INPUT_PARSING";
-      cause: TSafeFnParseError<z.input<TInputSchema>, TAsAction>;
-    }
-  : never;
-
-export interface TSafeFnInputParseRunError<TSchemaInput> {
-  code: "INPUT_PARSING";
-  cause: z.ZodError<TSchemaInput>;
+export interface TSafeFnParseErrorCause<TSchemaInput extends AnyValue> {
+  formattedError: z.ZodFormattedError<TSchemaInput>;
+  flattenedError: z.typeToFlattenedError<TSchemaInput>;
 }
 
-export interface TSafeFnInputParseActionError<TSchemaInput> {
-  code: "INPUT_PARSING";
-  cause: {
-    formattedError: z.ZodFormattedError<TSchemaInput>;
-    flattenedError: z.typeToFlattenedError<TSchemaInput>;
-  };
-}
-
-export interface TSafeFnOutputParseRunError<TSchemaInput> {
-  code: "OUTPUT_PARSING";
-  cause: z.ZodError<TSchemaInput>;
-}
-
-export interface TSafeFnOutputParseActionError<TSchemaInput> {
-  code: "OUTPUT_PARSING";
-  cause: {
-    formattedError: z.ZodFormattedError<TSchemaInput>;
-    flattenedError: z.typeToFlattenedError<TSchemaInput>;
-  };
-}
-
-export type TSafeFnOutputParseError<
-  TOutputSchema extends TSafeFnOutput,
-  TAsAction extends boolean,
-> = TOutputSchema extends z.ZodTypeAny
-  ? {
-      code: "OUTPUT_PARSING";
-      cause: TSafeFnParseError<z.input<TOutputSchema>, TAsAction>;
-    }
-  : never;
+export type TSafeFnInputParseErrorNoZod<T extends AnyValue | undefined> =
+  T extends AnyValue
+    ? {
+        code: "INPUT_PARSING";
+        cause: TSafeFnParseErrorCause<TPrettify<T>>;
+      }
+    : never;
+export type TSafeFnOutputParseErrorNoZod<T extends AnyValue | undefined> =
+  T extends AnyValue
+    ? {
+        code: "OUTPUT_PARSING";
+        cause: TSafeFnParseErrorCause<TPrettify<T>>;
+      }
+    : never;

--- a/packages/safe-fn/src/types/util.ts
+++ b/packages/safe-fn/src/types/util.ts
@@ -27,5 +27,7 @@ export type TIntersectIfNotT<A, B, T> = [A] extends [T]
 
 export type AnyObject = Record<PropertyKey, unknown>;
 
+export type AnyValue = AnyObject | string | number | boolean;
+
 export type FirstTupleElOrUndefined<T extends TSafeFnUnparsedInput> =
   T extends [] ? undefined : T[0];

--- a/packages/safe-fn/src/util.ts
+++ b/packages/safe-fn/src/util.ts
@@ -5,7 +5,7 @@ import type { AnyCtxInput } from "./types/handler";
 import type {
   TSafeFnInput,
   TSafeFnOutput,
-  TSafeFnParseError,
+  TSafeFnParseErrorCause,
   TSafeFnUnparsedInput,
 } from "./types/schema";
 
@@ -48,8 +48,7 @@ export const runCallbacks = <
     TCtxInput,
     TInputSchema,
     TOutputSchema,
-    TUnparsedInput,
-    NoInfer<TAsAction>
+    TUnparsedInput
   > = TSafeFnInternalRunReturn<
     TData,
     TRunErr,
@@ -57,12 +56,10 @@ export const runCallbacks = <
     TCtxInput,
     TInputSchema,
     TOutputSchema,
-    TUnparsedInput,
-    NoInfer<TAsAction>
+    TUnparsedInput
   >,
 >(args: {
   resultAsync: TRes;
-  asAction: TAsAction;
   callbacks: TSafeFnCallBacks<
     TData,
     TRunErr,
@@ -99,7 +96,6 @@ export const runCallbacks = <
         args.callbacks.onError,
         throwFrameworkErrorOrVoid,
       )({
-        asAction: args.asAction,
         error: res.error.public,
         ctx: res.error.private.ctx,
         ctxInput: res.error.private.ctxInput,
@@ -114,7 +110,6 @@ export const runCallbacks = <
         args.callbacks.onComplete,
         throwFrameworkErrorOrVoid,
       )({
-        asAction: args.asAction,
         result: res.match(
           (value) => ok(value.value),
           (error) => err(error.public),
@@ -194,5 +189,5 @@ export const mapZodError = <T>(
   return {
     formattedError: err.format(),
     flattenedError: err.flatten(),
-  } satisfies TSafeFnParseError<TODO, true>;
+  } satisfies TSafeFnParseErrorCause<TODO>;
 };

--- a/packages/safe-fn/src/util.ts
+++ b/packages/safe-fn/src/util.ts
@@ -40,7 +40,6 @@ export const runCallbacks = <
   TInputSchema extends TSafeFnInput,
   TOutputSchema extends TSafeFnOutput,
   TUnparsedInput extends TSafeFnUnparsedInput,
-  TAsAction extends boolean,
   TRes extends TSafeFnInternalRunReturn<
     TData,
     TRunErr,

--- a/packages/safe-fn/src/util.ts
+++ b/packages/safe-fn/src/util.ts
@@ -35,7 +35,6 @@ export const throwFrameworkErrorOrVoid = (error: unknown): void => {
 export const runCallbacks = <
   TData,
   TRunErr,
-  TActionErr,
   TCtx,
   TCtxInput extends AnyCtxInput,
   TInputSchema extends TSafeFnInput,
@@ -45,7 +44,6 @@ export const runCallbacks = <
   TRes extends TSafeFnInternalRunReturn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -55,7 +53,6 @@ export const runCallbacks = <
   > = TSafeFnInternalRunReturn<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,
@@ -69,7 +66,6 @@ export const runCallbacks = <
   callbacks: TSafeFnCallBacks<
     TData,
     TRunErr,
-    TActionErr,
     TCtx,
     TCtxInput,
     TInputSchema,


### PR DESCRIPTION
Removes action error. SafeFn will realistically only be used at edge of application anyway. ActionError made types more complex and would have introduced more complexity when implementing the mapErr function. 

Main disadvantage RN is logging but a solution for this can be made in another PR (attaching logging service that can take in raw errorrs). 