### PR TITLE
make types non distributive

### DIFF
--- a/.changeset/ten-beds-exercise.md
+++ b/.changeset/ten-beds-exercise.md
@@ -1,0 +1,6 @@
+---
+"safe-fn": patch
+"safe-fn-react": patch
+---
+
+Fix type issues with the hook (related to distribution)

--- a/packages/safe-fn/src/result.ts
+++ b/packages/safe-fn/src/result.ts
@@ -60,14 +60,23 @@ export type InferActionErrError<T> =
 /**
  * Converts a `ResultAsync<T,E>` to a `<ActionResult<T,E>`.
  */
-export type ResultAsyncToActionResult<T> =
-  T extends ResultAsync<infer D, infer E> ? ActionResult<D, E> : never;
+export type ResultAsyncToActionResult<T> = [T] extends [
+  ResultAsync<infer D, infer E>,
+]
+  ? ActionResult<D, E>
+  : never;
 
-export type ActionResultToResultAsync<T> =
-  T extends ActionResult<infer D, infer E> ? ResultAsync<D, E> : never;
+export type ActionResultToResultAsync<T> = [T] extends [
+  ActionResult<infer D, infer E>,
+]
+  ? ResultAsync<D, E>
+  : never;
 
-export type ActionResultToResult<T> =
-  T extends ActionResult<infer D, infer E> ? Result<D, E> : never;
+export type ActionResultToResult<T> = [T] extends [
+  ActionResult<infer D, infer E>,
+]
+  ? Result<D, E>
+  : never;
 
 /**
  * Converts an `ActionResult<T,E>` to a `Result<T,E>`.


### PR DESCRIPTION
Previously a type coming out of the hook could end up as `Result<"good", never> | Result<never, "bad">` instead of `Result<"good", "bad">`. This caused some weird issues when trying to discriminate by using `isOk()` and `isErr()`